### PR TITLE
Star geant4maker persistent tracks

### DIFF
--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -1155,8 +1155,7 @@ void StGeant4Maker::FinishEvent(){
     mytrack.start_vertex_p = truthVertex[ t->start() ];
     mytrack.stop_vertex_p  = truthVertex[ t->stop()  ];
     // next, track parent
-    auto* parent = t->start()->parent();
-    mytrack.next_parent_p = truthTrack[ parent ];    
+    mytrack.next_parent_p = truthTrack[ t->start()->parent() ];    
     //__________________________________________ next track
     g2t_track->AddAt(&mytrack);
     itrack++;

--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -547,17 +547,16 @@ StGeant4Maker::StGeant4Maker( const char* nm ) :
   SetAttr("LABS", 1);
   SetAttr("SYNC", 1);
 
-  SetAttr("all:engine",  "G3" );
-  // SetAttr("ecal:engine", "G3" );
-  // SetAttr("calb:engine", "G3" );
-  // SetAttr("tpce:engine", "G3" );
- 
+  SetAttr("all:engine",  "G3" ); // default engine in multi-engine mode is G3
+  SetAttr("calb:engine", "G4" ); // BEMC defaults to G4
+  SetAttr("ecal:engine", "G4" ); // EEMC defaults to G4
+  SetAttr("wcal:engine", "G4" ); // Forward EMC defaults to G4
+  SetAttr("hcal:engine", "G4" ); // Forward hcal defaults to G4
+
+  // Application defaults to single engine mode with Geant4
   SetAttr("application:engine","G4"); 
     
-  // TODO-- 
-  //  SetAttr( "AgMLOpt:Hits:Deactivate", "ECAL:*,TPCE:*,*" );
-  //  SetAttr( "AgMLOpt:Hits:Activate", "TPAD,CSUP,ESCI" );
-
+  // Naughty
   _g4maker = this; // Provide a global pointer to the G4 maker  
 
 }

--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -735,17 +735,18 @@ int StGeant4Maker::InitRun( int /* run */ ){
     result = kStFatal;
   }
   
-
   return result;
 }
 //________________________________________________________________________________________________
 void StarVMCApplication::ConstructGeometry(){ 
+  // Geometry construction is the responsability of the framework and should
+  // have already occurred.  If the geometry is missing, it should be fatal.
   if ( 0==gGeoManager ) {
     LOG_FATAL << "Geometry manager is not available at StarVMCApplication::ConstructGeometry... this will not go well" << endm;
   }
   gGeoManager->CloseGeometry(); 
-
 }
+//________________________________________________________________________________________________
 int  StGeant4Maker::InitGeom() {
 
   const DbAlias_t *DbAlias = GetDbAliases();
@@ -778,7 +779,6 @@ int  StGeant4Maker::InitGeom() {
       // Cleanup file
       // 
       if (mac) delete [] mac;
-
     }
   }
 
@@ -851,6 +851,21 @@ void StarVMCApplication::InitGeometry(){
 }
 //________________________________________________________________________________________________
 void StarVMCApplication::ConstructSensitiveDetectors() {
+
+  //
+  // This routine registers sensitive detectors to volumes.  Additionally,
+  // in multi-engine mode, this routine is responsible for associating
+  // a physics engine to each volume in the geometry.
+  //
+  // NOTE: physics engines are assigned at the granularity of geometry 
+  // modules.  Users have the ability to specify the physics engine for
+  // a given module (and all volumes defined within) by using the syntax
+  // 
+  // --syst:engine=G3 or --syst:engine=G4
+  //
+  // where "syst" denotes the first four letters of the name of the geometry
+  // module.
+  //
 
   assert(gGeoManager);
 
@@ -998,7 +1013,7 @@ void StGeant4Maker::SetEngineForModule( const char* module_, const int engine ) 
 
 }
 //________________________________________________________________________________________________
-  int  StGeant4Maker::ConfigureGeometry() {
+int  StGeant4Maker::ConfigureGeometry() {
 
   // Iterate overall volumes and set volume specific tracking cuts
   std::map<int, int> media;

--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -96,7 +96,7 @@ struct SD2Table_TPC {
       g2t_tpc_hit_st g2t_hit; memset(&g2t_hit,0,sizeof(g2t_tpc_hit_st)); 
       
       g2t_hit.id        = hit->id;
-      // TODO: add pointer to next hit on the track 
+
       g2t_hit.track_p   = hit->idtruth;
       g2t_hit.volume_id = hit->volId;
       g2t_hit.de        = hit->de;
@@ -108,6 +108,9 @@ struct SD2Table_TPC {
       g2t_hit.tof       = 0.5 * ( hit->position_in[3] + hit->position_out[3] ); 
       g2t_hit.length    = hit->length;
       g2t_hit.lgam      = hit->lgam;
+
+      
+
       /*
 	these are used downstream by the slow simulator (and should not be filled here)
 
@@ -117,12 +120,17 @@ struct SD2Table_TPC {
 	g2t_hit.np = ...; // number of primary electrons
 
       */
-      
-      table -> AddAt( &g2t_hit );     
 
       int idtruth = hit->idtruth;
-      g2t_track_st* trk = (g2t_track_st*)track->At(idtruth-1);
-      trk->n_tpc_hit++;     
+      g2t_track_st* g2t_track = (g2t_track_st*)track->At(idtruth-1);
+
+      g2t_hit.next_tr_hit_p = g2t_track->hit_tpc_p; // store next hit on the linked list
+      g2t_track->hit_tpc_p = hit->id;            // this hit becomes the head of the linked list
+      
+      g2t_track->n_tpc_hit++;     
+
+      // Add hit to the table
+      table -> AddAt( &g2t_hit );           
 
     }
     // TODO: increment hit count on track 
@@ -170,7 +178,6 @@ struct SD2Table_STGC {
       g2t_fts_hit_st g2t_hit; memset(&g2t_hit,0,sizeof(g2t_fts_hit_st)); 
       
       g2t_hit.id        = hit->id;
-      // TODO: add pointer to next hit on the track 
       g2t_hit.track_p   = hit->idtruth;
       g2t_hit.volume_id = hit->volId;
       g2t_hit.de        = hit->de;
@@ -179,13 +186,16 @@ struct SD2Table_STGC {
 	g2t_hit.p[i]  = 0.5 * ( hit->momentum_in[i] + hit->momentum_out[i] );
 	g2t_hit.x[i]  = 0.5 * ( hit->position_in[i] + hit->position_out[i] );
       }
-      g2t_hit.tof       = 0.5 * ( hit->position_in[3] + hit->position_out[3] ); 
-      
-      table -> AddAt( &g2t_hit );     
+      g2t_hit.tof       = 0.5 * ( hit->position_in[3] + hit->position_out[3] );             
 
       int idtruth = hit->idtruth;
-      g2t_track_st* trk = (g2t_track_st*)track->At(idtruth-1);
-      trk->n_stg_hit++;
+      g2t_track_st* g2t_track = (g2t_track_st*)track->At(idtruth-1);
+
+      g2t_hit.next_tr_hit_p = g2t_track->hit_stg_p; // store next hit on the linked list
+      g2t_track->hit_stg_p = hit->id;            // this hit becomes the head of the linked list
+      g2t_track->n_stg_hit++;
+
+      table -> AddAt( &g2t_hit );     
       
     }
   } 
@@ -210,12 +220,15 @@ struct SD2Table_FST {
 	g2t_hit.x[i]  = 0.5 * ( hit->position_in[i] + hit->position_out[i] );
       }
       g2t_hit.tof       = 0.5 * ( hit->position_in[3] + hit->position_out[3] ); 
-      
-      table -> AddAt( &g2t_hit );     
-
+     
       int idtruth = hit->idtruth;
-      g2t_track_st* trk = (g2t_track_st*)track->At(idtruth-1);
-      trk->n_fts_hit++;
+      g2t_track_st* g2t_track = (g2t_track_st*)track->At(idtruth-1);
+
+      g2t_hit.next_tr_hit_p = g2t_track->hit_fts_p; // store next hit on the linked list
+      g2t_track->hit_fts_p = hit->id;            // this hit becomes the head of the linked list
+      g2t_track->n_fts_hit++;
+
+      table -> AddAt( &g2t_hit );     
 
     }
   } 

--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -770,7 +770,7 @@ int  StGeant4Maker::InitGeom() {
       //
       TString  rtag = "r"; rtag += DbAlias[i].tag;
       TString   tag =              DbAlias[i].tag;
-      if ( 0==bfc->GetOption(rtag.Data()) && 0==bfc->GetOption(tag.Data()) ) continue;
+           if ( 0==bfc->GetOption(rtag.Data()) && 0==bfc->GetOption(tag.Data()) ) continue;
       //
       // Get the geometry generation macro
       //
@@ -839,12 +839,13 @@ int StGeant4Maker::Make() {
   // Increment event number
   eventNumber++;
 
+  // Dump the  stack at the end of make
+  //  mMCStack -> StackDump(); 
+
   return kStOK; 
 }
 //________________________________________________________________________________________________
 void StGeant4Maker::Clear( const Option_t* opts ){
-
-  mMCStack -> StackDump(); // stack dump before clear...
 
   mMCStack -> Clear(); // Clear the MC stack
   acurr = aprev = 0;   // zero out pointers to the current and previous agml extensions
@@ -925,7 +926,7 @@ void StarVMCApplication::ConstructSensitiveDetectors() {
     int efm = engineFromModule( mname.Data() );
 
     ae->SetEngine( engineFromModule( mname.Data() ) );
-    ae->Print();
+    //    ae->Print();
 
     if ( 0==ae->GetSensitive() ) {
       LOG_DEBUG << "Not sensitive = " << volume->GetName() << endm;

--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -248,7 +248,6 @@ struct SD2Table_EMC {
       g2t_emc_hit_st g2t_hit; memset(&g2t_hit,0,sizeof(g2t_emc_hit_st)); 
       
       g2t_hit.id        = hit->id;
-      // TODO: add pointer to next hit on the track 
       g2t_hit.track_p   = hit->idtruth;
       g2t_hit.volume_id = hit->volId;
       g2t_hit.de        = hit->de;
@@ -1131,7 +1130,7 @@ void StGeant4Maker::FinishEvent(){
     mytrack.p[0]     = t->px();
     mytrack.p[1]     = t->py();
     mytrack.p[2]     = t->pz();
-    mytrack.e        = t->E();
+    mytrack.e        = t->particle()->Energy();
     mytrack.pt       = t->pt(); // NOTE: starsim secondaries have pt = -999
     mytrack.eta      = t->particle()->Eta();
     mytrack.rapidity = t->particle()->Y();
@@ -1172,7 +1171,10 @@ void StGeant4Maker::BeginPrimary()
   truthTable.clear();
 
   int current = mMCStack->GetCurrentTrackNumber();
-  truthTable.push_back( mMCStack->GetPersistentTrack( current ) );
+  auto* track = mMCStack->GetPersistentTrack( current );
+  LOG_DEBUG << "Begin Primary current track number = " << current << " track=" << track << endm;
+  
+  truthTable.push_back( track ); 
 
 }
 //________________________________________________________________________________________________
@@ -1196,7 +1198,6 @@ void StGeant4Maker::PreTrack()
 
   mCurrentNode    = navigator->GetCurrentNode();
   mCurrentVolume  = navigator->GetCurrentVolume();
-
 }
 //________________________________________________________________________________________________
 void StarVMCApplication::PostTrack(){ _g4maker->PostTrack(); }

--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -844,6 +844,8 @@ int StGeant4Maker::Make() {
 //________________________________________________________________________________________________
 void StGeant4Maker::Clear( const Option_t* opts ){
 
+  mMCStack -> StackDump(); // stack dump before clear...
+
   mMCStack -> Clear(); // Clear the MC stack
   acurr = aprev = 0;   // zero out pointers to the current and previous agml extensions
 
@@ -1170,11 +1172,6 @@ void StGeant4Maker::BeginPrimary()
   std::vector<StarMCParticle*>& truthTable    = mMCStack->GetTruthTable();
   truthTable.clear();
 
-  int current = mMCStack->GetCurrentTrackNumber();
-  auto* track = mMCStack->GetPersistentTrack( current );
-  LOG_DEBUG << "Begin Primary current track number = " << current << " track=" << track << endm;
-  
-  truthTable.push_back( track ); 
 
 }
 //________________________________________________________________________________________________
@@ -1526,3 +1523,8 @@ int StGeant4Maker::Finish() {
 
   return kStOK;
 }
+
+
+
+//________________________________________________________________________________________________
+

--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -563,7 +563,6 @@ StGeant4Maker::StGeant4Maker( const char* nm ) :
 //________________________________________________________________________________________________
 int StGeant4Maker::Init() {
 
-
   InitGeom();
 
   mVmcApplication = new StarVMCApplication("g4star","STAR G4/VMC",DAttr("Application:Zmax"),DAttr("Application:Rmax"), SAttr("application:engine"), mMCStack );
@@ -583,7 +582,6 @@ int StGeant4Maker::Init() {
     gG4 = new TGeant4(SAttr("G4VmcOpt:Name"), SAttr("G4VmcOpt:Title") ,mRunConfig); // ID = 1 in multi engine
     LOG_INFO << "Created Geant 4 instance " << gG4->GetName() << endm;
   }
-
 
   if ( gG4 ) AddObj( gG4, ".const", 0 );
   if ( gG3 ) AddObj( gG3, ".const", 0 );
@@ -675,7 +673,6 @@ int StGeant4Maker::Init() {
     LOG_INFO << "Initialize Geant 4 + GEANT3 multiengine run" << endm;    
     TMCManager::Instance()->Init( InitializeMC );
 
-
   }
   
   // Geant4 standalone initialization
@@ -684,7 +681,6 @@ int StGeant4Maker::Init() {
     LOG_INFO << "Initialize Geant 4 standalone" << endm;
 
     InitializeMC( gG4 );
-    //SetStack( gG4 );
     
     TG4RunManager* runManager = TG4RunManager::Instance();
     runManager->UseRootRandom(false);
@@ -697,13 +693,8 @@ int StGeant4Maker::Init() {
     LOG_INFO << "Initialize GEANT3 standalone" << endm;
     
     InitializeMC( gG3 );
-    //SetStack( gG3 );
  
   }
-
-  // Create histograms
-  TH1* h;
-  AddHist( h = new TH2F("MC:vertex:RvsZ","MC vertex;z [cm];R [cm]",1801,-900.5,900.5,501,-0.5,500.5) );
 
   return StMaker::Init();
 }
@@ -1098,16 +1089,6 @@ void StGeant4Maker::FinishEvent(){
     myvertex.ge_medium = v->medium();
     myvertex.ge_proc   = v->process();
     myvertex.is_itrmd  = v->intermediate();
-
-    // Fill histograms
-    {
-      float& x = myvertex.ge_x[0];
-      float& y = myvertex.ge_x[1];
-      float& z = myvertex.ge_x[2];
-      float  r2 = x*x + y*y;
-      float  r = sqrt(r2);
-      GetHist("MC:vertex:RvsZ")->Fill(z,r);
-    }
 
     // TODO: map ROOT mechanism to G3 names
 

--- a/StRoot/StGeant4Maker/StGeant4Maker.h
+++ b/StRoot/StGeant4Maker/StGeant4Maker.h
@@ -13,6 +13,8 @@
 #include <string>
 #include "StMCParticleStack.h"
 
+#include <functional>
+
 class StGeant4Maker;
 
 class AgMLExtension;
@@ -153,8 +155,9 @@ public:
   void SetEngineForModule( const char* module_, const int engine );
 
   StMCParticleStack* stack(){ return mMCStack; }
-  
 
+  void AddUserPostSteppingAction( std::function<void()> f ) { mPostSteppingActions.push_back(f); }
+  
 private:
 protected:
 
@@ -222,7 +225,9 @@ protected:
 
   int mDefaultEngine;
 
-  ClassDef(StGeant4Maker,1);
+  std::vector< std::function<void()> > mPostSteppingActions;
+
+  ClassDef(StGeant4Maker,0);
 
 public:
 

--- a/StRoot/StGeant4Maker/StGeant4Maker.h
+++ b/StRoot/StGeant4Maker/StGeant4Maker.h
@@ -11,10 +11,9 @@
 #include <StSensitiveDetector.h> 
 #include <map>
 #include <string>
-
+#include "StMCParticleStack.h"
 
 class StGeant4Maker;
-class StMCParticleStack;
 
 class AgMLExtension;
 
@@ -152,6 +151,9 @@ public:
   
   /// Sets the MC engine for a given module
   void SetEngineForModule( const char* module_, const int engine );
+
+  StMCParticleStack* stack(){ return mMCStack; }
+  
 
 private:
 protected:

--- a/StRoot/StGeant4Maker/StHitCollection.cxx
+++ b/StRoot/StGeant4Maker/StHitCollection.cxx
@@ -145,7 +145,7 @@ void StTrackerHitCollection::ProcessHits() {
   std::vector<StarMCParticle*>& particleTable = userstack->GetParticleTable();
 
   // This should be the current particle truth 
-  StarMCParticle* truth = truthTable.back();
+  StarMCParticle* truth = userstack->GetCurrentPersistentTrack(); 
 
   LOG_DEBUG << "Process hits with track " << truth << " current tn=" << userstack->GetCurrentTrackNumber() << endm;
 
@@ -295,7 +295,7 @@ void StCalorimeterHitCollection::ProcessHits() {
   std::vector<StarMCParticle*>& particleTable = userstack->GetParticleTable();
 
   // This should be the current particle truth 
-  StarMCParticle* truth = truthTable.back();
+  StarMCParticle* truth = userstack->GetCurrentPersistentTrack(); 
 
   LOG_DEBUG << "Process hits with track " << truth << " current tn=" << userstack->GetCurrentTrackNumber() << endm;
 

--- a/StRoot/StGeant4Maker/StHitCollection.cxx
+++ b/StRoot/StGeant4Maker/StHitCollection.cxx
@@ -147,6 +147,8 @@ void StTrackerHitCollection::ProcessHits() {
   // This should be the current particle truth 
   StarMCParticle* truth = truthTable.back();
 
+  LOG_DEBUG << "Process hits with track " << truth << " current tn=" << userstack->GetCurrentTrackNumber() << endm;
+
   bool isNewTrack      = mc->IsNewTrack();
   bool isTrackEntering = mc->IsTrackEntering();
   bool isTrackExiting  = mc->IsTrackExiting();
@@ -295,6 +297,7 @@ void StCalorimeterHitCollection::ProcessHits() {
   // This should be the current particle truth 
   StarMCParticle* truth = truthTable.back();
 
+  LOG_DEBUG << "Process hits with track " << truth << " current tn=" << userstack->GetCurrentTrackNumber() << endm;
 
   bool isNewTrack      = mc->IsNewTrack();
   bool isTrackEntering = mc->IsTrackEntering();

--- a/StRoot/StGeant4Maker/StMCParticleStack.cxx
+++ b/StRoot/StGeant4Maker/StMCParticleStack.cxx
@@ -260,6 +260,8 @@ TParticle *StMCParticleStack::PopNextTrack( int &itrack )
   // Get the particle on the top of the stack
   TParticle *particle = mStack.back();    mStack.pop_back();
   itrack              = mStackIdx.back(); mStackIdx.pop_back();
+
+  // Set the current track number
   mCurrent            = itrack;
   
   return particle;

--- a/StRoot/StGeant4Maker/StMCParticleStack.cxx
+++ b/StRoot/StGeant4Maker/StMCParticleStack.cxx
@@ -464,14 +464,11 @@ ostream& operator<<(ostream& os, const Particle& part ) {
   double vy = part.st->vy();
   double vz = part.st->vz();
 
-  static auto* navigator    = gGeoManager->GetCurrentNavigator();
-         auto* node         = navigator->FindNode( vx, vy, vz );   
-         //auto* volume       = (node) ? node->GetVolume() : 0;  
+  // static auto* navigator    = gGeoManager->GetCurrentNavigator();
+  //        auto* node         = navigator->FindNode( vx, vy, vz );   
+  //        //auto* volume       = (node) ? node->GetVolume() : 0;  
 
-	 std::string volume = navigator->GetPath();
-
-	 
-
+  // 	 std::string volume = navigator->GetPath();       
 
   os << Form( "%-5i %-5i %-6.3f %-6.3f %-6.3f %-6.3f %-6.3f %-6.3f %4i %4i %s", 
 	      part.st->GetPdg(),
@@ -479,8 +476,7 @@ ostream& operator<<(ostream& os, const Particle& part ) {
 	      part.st->px(),part.st->py(),part.st->pz(),
 	      part.st->vx(),part.st->vy(),part.st->vz(),
 	      part.st->idTruth(),
-	      part.st->numberOfHits(),
-	      volume.c_str()
+	      part.st->numberOfHits()
 	      );
 
 

--- a/StRoot/StGeant4Maker/StMCParticleStack.h
+++ b/StRoot/StGeant4Maker/StMCParticleStack.h
@@ -121,7 +121,7 @@ public:
   TMCProcess process() const { return mMechanism; }
 
   void setVolume( const char* name ){ mVolume = name; }
-  std::string volume(){ return mVolume; }
+  std::string volume() const { return mVolume; }
 
   void setIntermediate( bool stat=true ){ mIntermediate=true; }
   bool intermediate(){ return mIntermediate; }
@@ -214,6 +214,9 @@ class StMCParticleStack : public TVirtualMCStack
   /// Get the current stack size
   virtual int GetStackSize(){ return mStack.size(); }
 
+  /// Print out the particle table
+  void StackDump();
+
 
   /// Obtain the current particle truth
 //  const StarMCParticle* GetCurrentTruth() const { return mParticleTable.back(); }
@@ -224,7 +227,7 @@ class StMCParticleStack : public TVirtualMCStack
 
   StarMCVertex* GetVertex( double vx, double vy, double vz, double vt, int proc=-1 );
 
-  StarMCParticle* GetPersistentTrack( int stackIndex );
+  StarMCParticle* GetCurrentPersistentTrack();
 
   int GetIdTruth( StarMCParticle* part ){ return mIdTruthFromParticle[part]; }
 
@@ -242,10 +245,12 @@ class StMCParticleStack : public TVirtualMCStack
 
   int                 mArraySize;
   TClonesArray       *mArray; 
+  std::vector<StarMCParticle *> mPersistentTrack;
 
-  int                      mStackSize;
-  std::list  <TParticle *> mStack;
-  std::list  <int>         mStackIdx;
+  int                           mStackSize;
+  std::list  <TParticle *>      mStack;     // note: vector may be faster
+  std::list  <int>              mStackIdx;  // note: vector may be faster 
+
 
 
   std::vector<StarMCParticle *> mTruthTable;
@@ -253,7 +258,6 @@ class StMCParticleStack : public TVirtualMCStack
   std::vector<StarMCVertex   *> mVertexTable;
 
   std::map<int, StarMCParticle*> mStackToTable;
-
   std::map<StarMCParticle*, int> mIdTruthFromParticle;
 
   float mScoringRmax;

--- a/StRoot/StGeant4Maker/StMCParticleStack.h
+++ b/StRoot/StGeant4Maker/StMCParticleStack.h
@@ -115,8 +115,8 @@ public:
   void setParent  ( StarMCParticle* _parent   ){ mParent = _parent; } 
   void addDaughter( StarMCParticle* daughter ){ mDaughters.push_back( daughter ); } 
 
-  const             StarMCParticle*   parent()   { return mParent; } 
-  const std::vector<StarMCParticle*>& daughters(){ return mDaughters; } 
+  const             StarMCParticle*   parent()    const { return mParent; } 
+  const std::vector<StarMCParticle*>& daughters() const { return mDaughters; } 
 
   void setMedium( const int medium ) { mMedium = medium; }
   int  medium() const { return mMedium; }

--- a/StRoot/StGeant4Maker/StMCParticleStack.h
+++ b/StRoot/StGeant4Maker/StMCParticleStack.h
@@ -64,6 +64,9 @@ public:
   void setIdStack( int id ) { mIdStack = id; } 
   int     idStack() const { return mIdStack; } 
 
+  void setIdTruth( int id ) { mIdTruth = id; }
+  int     idTruth() const { return mIdTruth; }
+
   //const long long numberOfHits(){ return mNumHits; } 
   //void  addHit(){ mNumHits++; } 
 
@@ -82,6 +85,7 @@ protected:
   StarMCVertex*              mStopVertex;           /// Pointer to the stop vertex  
 
   int                        mIdStack;              /// Track identity on stack 
+  int                        mIdTruth;
   long long                  mNumHits;              /// Number of hits registered on the track 
 
   std::vector<DetectorHit*>  mHits;                 /// List of hits on track
@@ -215,7 +219,7 @@ class StMCParticleStack : public TVirtualMCStack
   virtual int GetStackSize(){ return mStack.size(); }
 
   /// Print out the particle table
-  void StackDump();
+  void StackDump( int idtruth=-1 );
 
 
   /// Obtain the current particle truth

--- a/StRoot/StGeant4Maker/StMCParticleStack.h
+++ b/StRoot/StGeant4Maker/StMCParticleStack.h
@@ -177,8 +177,7 @@ class StMCParticleStack : public TVirtualMCStack
 			  TMCProcess mech, int& ntr, double weight,
 			  int is);
 
-
-
+ 
   /// The stack has to provide two pop mechanisms:
   /// The first pop mechanism required.
   /// Pop all particles with toBeDone = 1, both primaries and seconadies.

--- a/StRoot/StGeant4Maker/tests/unit_test_multi_engine_emc.C
+++ b/StRoot/StGeant4Maker/tests/unit_test_multi_engine_emc.C
@@ -85,6 +85,7 @@ void trackLoop() {
        	double pt = track->pt;
        	double eta = track->eta;
        	if ( pt > 0.100 && pt < 10.0 ) {
+	  LOG_INFO << "Accumulate track->id = " << track->id << " hit de = " << hit->de << std::endl;
        	  edep_per_track[ track->id ] += hit->de; // running sum
        	}	
        }
@@ -99,6 +100,7 @@ void trackLoop() {
        double eta = track->eta;
        // todo phi
        double E  = track->e + 1.0e-12; // prevent div by zero
+       LOG_INFO << "itrack=" << i << " idtruth=" << track->id << "Fill pt=" << pt << " eta=" << track->eta << " E=" << track->e << " edep=" << edep_per_track[ track->id ] << endm;
        if ( pt > 0.100 && pt < 10.0 && eta > -0.95 && eta < 0.95 ) {
    	sampling_fraction_vs_pt.back()->Fill( pt, edep_per_track[ track->id ] / E );
    	sampling_fraction_vs_eta.back()->Fill( eta, edep_per_track[ track->id ] / E );
@@ -137,7 +139,7 @@ void book_histograms() {
 
 }
 //___________________________________________________________________
-void unit_test_multi_engine_emc( int ntracks = 5, const char* part = "gamma" ) {
+void unit_test_multi_engine_emc( const char* part = "gamma", int ntracks = 10 ) {
 
   gROOT->ProcessLine("initChain();");
 
@@ -154,9 +156,11 @@ void unit_test_multi_engine_emc( int ntracks = 5, const char* part = "gamma" ) {
 
   auto* gm = dynamic_cast<StGeant4Maker*>( StMaker::GetChain()->GetMaker("geant4star") );
 
+  TFile* output = new TFile(Form("unit_test_multi_engine_emc_%s.root",part),"recreate");
+
   gm->SetEngineForModule( "CALB", 0 ); 
   book_histograms();
-  throw_particle(ntracks, part, 0.099995, 10.00005, -0.95, 0.95, 0., TMath::TwoPi() );
+  throw_particle(ntracks, part, 0.09995, 10.00005, -0.95, 0.95, 0., TMath::TwoPi() );
   trackLoop();
 
   LOG_TEST << "=======================================================" << std::endl;
@@ -167,8 +171,11 @@ void unit_test_multi_engine_emc( int ntracks = 5, const char* part = "gamma" ) {
 
   gm->SetEngineForModule( "CALB", 1 );
   book_histograms();
-  throw_particle(ntracks, part, 0.99995, 1.00005, -0.95, 0.95, 0., TMath::TwoPi() );
+  throw_particle(ntracks, part, 0.09995, 10.00005, -0.95, 0.95, 0., TMath::TwoPi() );
   trackLoop();
+
+  output->Write();
+  output->Close();
 
   LOG_TEST << "=======================================================" << std::endl;
   LOG_TEST << "Multi-engine testing of EMC" << std::endl;
@@ -183,7 +190,7 @@ void unit_test_multi_engine_emc( int ntracks = 5, const char* part = "gamma" ) {
   LOG_TEST << Form( "energy deposition: max           = %f %f keV", max_[0], max_[1]  )          << std::endl;
   LOG_TEST << Form( "energy deposition: error of mean = %f %f keV", error_of_mean_[0], error_of_mean_[1] ) << std::endl;
   LOG_TEST << Form( "number of hits:                    %i %i    ", nhits_[0], nhits_[1]         ) << std::endl;
-
+  
 }
 
 

--- a/StRoot/StGeant4Maker/tests/unit_test_multi_engine_emc.C
+++ b/StRoot/StGeant4Maker/tests/unit_test_multi_engine_emc.C
@@ -4,6 +4,8 @@
 #include "TMath.h"
 #include "TProfile.h"
 
+
+
 #ifndef __CINT__
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
@@ -40,9 +42,22 @@ const double phi0 = 0.0; // not really...
 
 
 //___________________________________________________________________
+
+// Obtain a track pointer from the given hit
+template<typename Hit> const g2t_track_st* get_track( Hit* hit ) {
+  int index = hit->track_p - 1;
+  if ( index < 0 || index > track_table->GetNRows() ) {
+    return 0;
+  } 
+  else {
+    return static_cast<const g2t_track_st*>( track_table -> At( index ) );
+  }
+}
+
+//___________________________________________________________________
 std::vector<double> mean_, median_, min_, max_, error_of_mean_, sum_;
 std::vector<int> nhits_;
-void eventSums() {
+void trackLoop() {
 
   auto* chain = StMaker::GetChain();
   vertex_table = dynamic_cast<TTable*>( chain->GetDataSet("g2t_vertex")  );
@@ -50,6 +65,8 @@ void eventSums() {
   hit_table    = dynamic_cast<TTable*>( chain->GetDataSet("g2t_emc_hit") ) ;
 
   Accumulator_t edep; // Energy deposition
+
+  std::map< int, double > edep_per_track;
 
   // Loop on all hits and accumulate all energy depositions
   int nh = hit_table->GetNRows();
@@ -62,7 +79,33 @@ void eventSums() {
       // accumulate energy deposition
       edep( hit->de );
 
+       // accumulate sampling fraction
+       auto* track = get_track( hit );
+       if ( track ) {
+       	double pt = track->pt;
+       	double eta = track->eta;
+       	if ( pt > 0.100 && pt < 10.0 ) {
+       	  edep_per_track[ track->id ] += hit->de; // running sum
+       	}	
+       }
+
   }
+
+   // Fill histograms
+   for ( int i=0;i<track_table->GetNRows(); i++ ) {
+     const g2t_track_st* track = static_cast<const g2t_track_st*>( track_table->At(i) );
+     if ( track ) {
+       double pt = track->pt;
+       double eta = track->eta;
+       // todo phi
+       double E  = track->e + 1.0e-12; // prevent div by zero
+       if ( pt > 0.100 && pt < 10.0 && eta > -0.95 && eta < 0.95 ) {
+   	sampling_fraction_vs_pt.back()->Fill( pt, edep_per_track[ track->id ] / E );
+   	sampling_fraction_vs_eta.back()->Fill( eta, edep_per_track[ track->id ] / E );
+       }
+     }
+   }
+
 
   double _sum           = boost::accumulators::sum(edep);
   double _mean          = boost::accumulators::mean(edep);
@@ -79,9 +122,22 @@ void eventSums() {
   error_of_mean_.push_back(_error_of_mean);
 
 }
-
 //___________________________________________________________________
-void unit_test_multi_engine_emc( int ntracks = 500, const char* part = "pi+" ) {
+void book_histograms() {
+
+  const char* engines[] = { "geant3", "geant4" };
+  assert(sampling_fraction_vs_pt.size() < sizeof(engines)/sizeof(const char*) );
+
+  TString base  = Form( "%s_sampling_fraction_vs_",    engines[ sampling_fraction_vs_pt.size() ] );
+  TString title = Form( "EMC Sampling fraction [%s]", engines[ sampling_fraction_vs_pt.size() ] );
+
+  sampling_fraction_vs_pt.push_back ( new TProfile(base+"pt",  title+";p_{T}", 50,  0., 10.0, 0.0, 1.0 ) );
+  sampling_fraction_vs_eta.push_back( new TProfile(base+"eta", title+";#eta",  40, -0.95, 0.95, 0.0, 1.0 ) );
+  sampling_fraction_vs_phi.push_back( new TProfile(base+"phi", title+";#phi",  60, 0., TMath::TwoPi(), 0.0, 1.0 ) );
+
+}
+//___________________________________________________________________
+void unit_test_multi_engine_emc( int ntracks = 5, const char* part = "gamma" ) {
 
   gROOT->ProcessLine("initChain();");
 
@@ -99,8 +155,9 @@ void unit_test_multi_engine_emc( int ntracks = 500, const char* part = "pi+" ) {
   auto* gm = dynamic_cast<StGeant4Maker*>( StMaker::GetChain()->GetMaker("geant4star") );
 
   gm->SetEngineForModule( "CALB", 0 ); 
-  throw_particle(ntracks, part, 0.99995, 1.00005, -0.95, 0.95, 0., TMath::TwoPi() );
-  eventSums();
+  book_histograms();
+  throw_particle(ntracks, part, 0.099995, 10.00005, -0.95, 0.95, 0., TMath::TwoPi() );
+  trackLoop();
 
   LOG_TEST << "=======================================================" << std::endl;
   LOG_TEST << "Multi-engine testing of EMC" << std::endl;
@@ -109,8 +166,9 @@ void unit_test_multi_engine_emc( int ntracks = 500, const char* part = "pi+" ) {
   LOG_TEST << "=======================================================" << std::endl;
 
   gm->SetEngineForModule( "CALB", 1 );
+  book_histograms();
   throw_particle(ntracks, part, 0.99995, 1.00005, -0.95, 0.95, 0., TMath::TwoPi() );
-  eventSums();
+  trackLoop();
 
   LOG_TEST << "=======================================================" << std::endl;
   LOG_TEST << "Multi-engine testing of EMC" << std::endl;

--- a/StRoot/StGeant4Maker/tests/unit_test_multi_engine_emc.C
+++ b/StRoot/StGeant4Maker/tests/unit_test_multi_engine_emc.C
@@ -2,6 +2,7 @@
 
 #include "StGeant4Maker.h"
 #include "TMath.h"
+#include "TProfile.h"
 
 #ifndef __CINT__
 #include <boost/accumulators/accumulators.hpp>
@@ -25,6 +26,10 @@ stats< tag::count,
        tag::error_of<tag::mean>
        >>;
 #endif
+
+std::vector<TProfile*> sampling_fraction_vs_pt;
+std::vector<TProfile*> sampling_fraction_vs_eta;
+std::vector<TProfile*> sampling_fraction_vs_phi;
 
 #include <vector>
 //___________________________________________________________________
@@ -76,7 +81,7 @@ void eventSums() {
 }
 
 //___________________________________________________________________
-void unit_test_multi_engine_emc( int nevents = 5, const char* part = "pi+" ) {
+void unit_test_multi_engine_emc( int ntracks = 500, const char* part = "pi+" ) {
 
   gROOT->ProcessLine("initChain();");
 
@@ -87,30 +92,30 @@ void unit_test_multi_engine_emc( int nevents = 5, const char* part = "pi+" ) {
   LOG_TEST << "=======================================================" << std::endl;
   LOG_TEST << "Multi-engine testing of EMC" << std::endl;
   LOG_TEST << "=======================================================" << std::endl;
-  LOG_TEST << Form("GEANT3 response to %i 1 GeV photons %s",nevents,part) << std::endl;
+  LOG_TEST << Form("GEANT3 response to %i 1 GeV photons %s",ntracks,part) << std::endl;
   LOG_TEST << "=======================================================" << std::endl;
 
 
   auto* gm = dynamic_cast<StGeant4Maker*>( StMaker::GetChain()->GetMaker("geant4star") );
 
   gm->SetEngineForModule( "CALB", 0 ); 
-  throw_particle(nevents, part, 0.99995, 1.00005, -0.95, 0.95, 0., TMath::TwoPi() );
+  throw_particle(ntracks, part, 0.99995, 1.00005, -0.95, 0.95, 0., TMath::TwoPi() );
   eventSums();
 
   LOG_TEST << "=======================================================" << std::endl;
   LOG_TEST << "Multi-engine testing of EMC" << std::endl;
   LOG_TEST << "=======================================================" << std::endl;
-  LOG_TEST << Form("Geant 4 response to %i 1 GeV %s",nevents,part) << std::endl;
+  LOG_TEST << Form("Geant 4 response to %i 1 GeV %s",ntracks,part) << std::endl;
   LOG_TEST << "=======================================================" << std::endl;
 
   gm->SetEngineForModule( "CALB", 1 );
-  throw_particle(nevents, part, 0.99995, 1.00005, -0.95, 0.95, 0., TMath::TwoPi() );
+  throw_particle(ntracks, part, 0.99995, 1.00005, -0.95, 0.95, 0., TMath::TwoPi() );
   eventSums();
 
   LOG_TEST << "=======================================================" << std::endl;
   LOG_TEST << "Multi-engine testing of EMC" << std::endl;
   LOG_TEST << "=======================================================" << std::endl;
-  LOG_TEST << Form("GEANT3 vs Geant 4 response to %i 1 GeV %s",nevents,part) << std::endl;
+  LOG_TEST << Form("GEANT3 vs Geant 4 response to %i 1 GeV %s",ntracks,part) << std::endl;
   LOG_TEST << "=======================================================" << std::endl;
 
   LOG_TEST << Form( "energy deposition: sum           = %f %f keV", sum_[0], sum_[1] )          << std::endl;

--- a/StRoot/StGeant4Maker/tests/unit_test_single_engine_emc.C
+++ b/StRoot/StGeant4Maker/tests/unit_test_single_engine_emc.C
@@ -1,0 +1,191 @@
+#include "tests/unit_tests.h"
+
+#include "StGeant4Maker.h"
+#include "TMath.h"
+#include "TProfile.h"
+
+
+
+#ifndef __CINT__
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
+#include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/median.hpp>
+#include <boost/accumulators/statistics/min.hpp>
+#include <boost/accumulators/statistics/max.hpp>
+#include <boost/accumulators/statistics/moment.hpp>
+#include <boost/accumulators/statistics/error_of.hpp>
+#include <boost/accumulators/statistics/error_of_mean.hpp>
+using namespace boost::accumulators;
+
+using Accumulator_t = accumulator_set<double, 
+stats< tag::count, 
+       tag::sum,
+       tag::mean, 
+       tag::median(with_p_square_quantile),
+       tag::max, 
+       tag::min, 
+       tag::error_of<tag::mean>
+       >>;
+#endif
+
+std::vector<TProfile*> sampling_fraction_vs_pt;
+std::vector<TProfile*> sampling_fraction_vs_eta;
+std::vector<TProfile*> sampling_fraction_vs_phi;
+
+#include <vector>
+//___________________________________________________________________
+const int neta = 40;
+const int nphi = 120;
+const double dphi = 3.0;
+const double phi0 = 0.0; // not really...
+
+
+//___________________________________________________________________
+
+// Obtain a track pointer from the given hit
+template<typename Hit> const g2t_track_st* get_track( Hit* hit ) {
+  int index = hit->track_p - 1;
+  if ( index < 0 || index > track_table->GetNRows() ) {
+    return 0;
+  } 
+  else {
+    return static_cast<const g2t_track_st*>( track_table -> At( index ) );
+  }
+}
+
+//___________________________________________________________________
+std::vector<double> mean_, median_, min_, max_, error_of_mean_, sum_;
+std::vector<int> nhits_;
+void trackLoop() {
+
+  auto* chain = StMaker::GetChain();
+  vertex_table = dynamic_cast<TTable*>( chain->GetDataSet("g2t_vertex")  );
+  track_table  = dynamic_cast<TTable*>( chain->GetDataSet("g2t_track")   );
+  hit_table    = dynamic_cast<TTable*>( chain->GetDataSet("g2t_emc_hit") ) ;
+
+  Accumulator_t edep; // Energy deposition
+
+  std::map< int, double > edep_per_track;
+
+  // Loop on all hits and accumulate all energy depositions
+  int nh = hit_table->GetNRows();
+  nhits_.push_back(nh);
+  for ( int i=0;i<hit_table->GetNRows();i++ ) {
+
+      auto hit = static_cast<const g2t_emc_hit_st*>( hit_table->At(i) );
+      if ( 0==hit ) continue;     // skip null entries
+
+      // accumulate energy deposition
+      edep( hit->de );
+
+       // accumulate sampling fraction
+       auto* track = get_track( hit );
+       if ( track ) {
+       	double pt = track->pt;
+       	double eta = track->eta;
+       	if ( pt > 0.100 && pt < 10.0 ) {
+	  LOG_INFO << "Accumulate track->id = " << track->id << " hit de = " << hit->de << std::endl;
+       	  edep_per_track[ track->id ] += hit->de; // running sum
+       	}	
+       }
+
+  }
+
+   // Fill histograms
+   for ( int i=0;i<track_table->GetNRows(); i++ ) {
+     const g2t_track_st* track = static_cast<const g2t_track_st*>( track_table->At(i) );
+     if ( track ) {
+       double pt = track->pt;
+       double eta = track->eta;
+       // todo phi
+       double E  = track->e + 1.0e-12; // prevent div by zero
+       LOG_INFO << "itrack=" << i << " idtruth=" << track->id << "Fill pt=" << pt << " eta=" << track->eta << " E=" << track->e << " edep=" << edep_per_track[ track->id ] << endl;
+       if ( pt > 0.100 && pt < 10.0 && eta > -0.95 && eta < 0.95 ) {
+   	sampling_fraction_vs_pt.back()->Fill( pt, edep_per_track[ track->id ] / E );
+   	sampling_fraction_vs_eta.back()->Fill( eta, edep_per_track[ track->id ] / E );
+       }
+     }
+   }
+
+
+  double _sum           = boost::accumulators::sum(edep);
+  double _mean          = boost::accumulators::mean(edep);
+  double _median        = boost::accumulators::median(edep);
+  double _min           = boost::accumulators::min(edep);
+  double _max           = boost::accumulators::max(edep);
+  double _error_of_mean = boost::accumulators::error_of<tag::mean>(edep);
+    
+  sum_.push_back(_sum);
+  mean_.push_back(_mean);
+  median_.push_back(_median);
+  min_.push_back(_min);
+  max_.push_back(_max);
+  error_of_mean_.push_back(_error_of_mean);
+
+}
+//___________________________________________________________________
+void book_histograms() {
+
+  const char* engines[] = { "geant3", "geant4" };
+  assert(sampling_fraction_vs_pt.size() < sizeof(engines)/sizeof(const char*) );
+
+  TString base  = Form( "%s_sampling_fraction_vs_",    engines[ sampling_fraction_vs_pt.size() ] );
+  TString title = Form( "EMC Sampling fraction [%s]", engines[ sampling_fraction_vs_pt.size() ] );
+
+  sampling_fraction_vs_pt.push_back ( new TProfile(base+"pt",  title+";p_{T}", 50,  0., 10.0, 0.0, 1.0 ) );
+  sampling_fraction_vs_eta.push_back( new TProfile(base+"eta", title+";#eta",  40, -0.95, 0.95, 0.0, 1.0 ) );
+  sampling_fraction_vs_phi.push_back( new TProfile(base+"phi", title+";#phi",  60, 0., TMath::TwoPi(), 0.0, 1.0 ) );
+
+}
+//___________________________________________________________________
+void unit_test_single_engine_emc( const char* part = "mu+", int ntracks = 10 ) {
+
+  gROOT->ProcessLine("initChain();");
+
+  TString engineName;
+  if ( hasRuntimeArg("application:engine=G3") ) engineName = "GEANT3 ";
+  if ( hasRuntimeArg("application:engine=G4") ) engineName = "Geant 4 ";
+  std::cout << "Engine name = " << engineName.Data() << endl;
+
+  auto* pm = dynamic_cast<StarPrimaryMaker*>( StMaker::GetChain()->GetMaker("PrimaryMaker") );
+  pm->SetVertex(0.,0.,0.);
+  pm->SetSigma(0.0,0.,0.);
+
+  LOG_TEST << "=======================================================" << std::endl;
+  LOG_TEST << "Single-engine testing of EMC" << std::endl;
+  LOG_TEST << "=======================================================" << std::endl;
+  LOG_TEST << Form("GEANT3 response to %i 1 GeV photons %s",ntracks,part) << std::endl;
+  LOG_TEST << "=======================================================" << std::endl;
+
+
+  auto* gm = dynamic_cast<StGeant4Maker*>( StMaker::GetChain()->GetMaker("geant4star") );
+
+  throw_particle(ntracks, part, 0.09995, 10.00005, -0.95, 0.95, 0., TMath::TwoPi() );
+
+  vertex_table = dynamic_cast<TTable*>( chain->GetDataSet("g2t_vertex")  );
+  track_table  = dynamic_cast<TTable*>( chain->GetDataSet("g2t_track")   );
+  hit_table    = dynamic_cast<TTable*>( chain->GetDataSet("g2t_emc_hit") ) ;
+
+  auto all_primary_tracks_have_hits = [=](g2t_track_st* begin_, g2t_track_st* end_) {
+   
+    int count = 0;
+    int hits  = 0;
+    for ( const auto* track=begin_; track < end_; track++ ) {
+
+      if ( track->n_emc_hit ) hits++;
+      if ( ++count == ntracks ) break;
+
+    }
+    return (hits == count) ? PASS : FAIL;
+
+  };
+
+  check_track_table( "All primary tracks have hits", all_primary_tracks_have_hits );
+      
+  return;
+  
+}
+
+
+

--- a/pams/sim/idl/g2t_track.idl
+++ b/pams/sim/idl/g2t_track.idl
@@ -88,6 +88,7 @@ struct g2t_track {
        long      hit_etr_p;  /* Id of first etr hit on track linked list */
        long      hit_hca_p;  /* Id of first hca hit on track linked list */
        long      hit_fts_p;  /* Id of first fts hit on track linked list */
+       long      hit_stg_p;  /* Id of first stg hit on track linked list */
        long      hit_eto_p;  /* Id of first etof hit on track linked list */ 
        long      hit_wca_p;  /* Id of first wca hit on track linked list */
        long      hit_pre_p;  /* Id of first pre hit on track linked list */


### PR DESCRIPTION

1) Resolve issue with Geant 4 not scoring hits in multi-engine mode.  SD initialization through TMCManager in multi-engine mode.

2) Simplify IDtruth scheme.  Keep array of pointers to the IDtruth particle for each particle created in the event.

3) Improve bookkeeping in the g2t tables (index to next-hit-on-track)

4) Track propagation cuts initialize w/ TMCManager

5) User-defined post-stepping actions can be registered with the maker


