### PR TITLE
Fix BBC volume ids. Fix bsmdp energy no energy loss in geant3.

### DIFF
--- a/StRoot/StGeant4Maker/AgMLBbcVolumeId.h
+++ b/StRoot/StGeant4Maker/AgMLBbcVolumeId.h
@@ -22,24 +22,26 @@ public:
     
     int _id;
     if (StarGeometry::HasDetector("BBCMin")){
-    // In the old geometry (before the 2018 EPD upgrade), BBC large tiles were included, 
-    // so the BBCA volume (Annulus) was placed twice (small and large). 
-    // This made it a multi-placed volume, so it was included in the numbv array:
-    // numbv[0] = BBCM (West/East: 1 or 2)
-    // numbv[1] = BBCA (Annulus Small/Large: 1 or 2)
-    // numbv[2] = THXM (Triple Module: 1 to 6)
-    // numbv[3] = SHXT (Single Module: 1 to 3)
-
-    // In the new geometry (2018 onwards), BBC large tiles were removed.
-    // BBCA is only placed once (small tiles only)
-    // The array elements shift left by one:
-    // numbv[0] = BBCM (West/East: 1 or 2)
-    // numbv[1] = THXM (Triple Module: 1 to 6)
-    // numbv[2] = SHXT (Single Module: 1 to 3)
-    // numbv[3] = 0 (Empty)
+      // New geometry (2018 onwards, after the EPD upgrade):
+      // BBC large tiles were removed, so BBCA is only placed once (small tiles only).
+      // As a result, the effective indices in numbv shift left by one:
+      //   numbv[0] = BBCM (West/East: 1 or 2)
+      //   numbv[1] = THXM (Triple Module: 1 to 6)
+      //   numbv[2] = SHXT (Single Module: 1 to 3)
+      //   numbv[3] = 0 (unused)
+      //
+      // We encode the (single) annulus placement with a fixed "1" in the hundreds place.
       _id = 1000 * numbv[0] + 100 * 1 + 10 * numbv[1] + numbv[2];
     }
     else {
+      // Old geometry (before the 2018 EPD upgrade):
+      // BBC large tiles were included, so the BBCA volume (Annulus) was placed twice
+      // (small and large). This made it a multi-placed volume, so it was included
+      // explicitly in the numbv array:
+      //   numbv[0] = BBCM (West/East: 1 or 2)
+      //   numbv[1] = BBCA (Annulus Small/Large: 1 or 2)
+      //   numbv[2] = THXM (Triple Module: 1 to 6)
+      //   numbv[3] = SHXT (Single Module: 1 to 3)
       _id = 1000 * numbv[0] + 100 * numbv[1] + 10 * numbv[2] + numbv[3];
     }
 

--- a/StRoot/StGeant4Maker/AgMLBbcVolumeId.h
+++ b/StRoot/StGeant4Maker/AgMLBbcVolumeId.h
@@ -19,8 +19,29 @@ public:
   // Applies to btog.version = 8 with btog.choice =13 (run 13 onwards)
   
   virtual int id( int* numbv ) const { 
+    
+    int _id;
+    if (StarGeometry::HasDetector("BBCMin")){
+    // In the old geometry (before the 2018 EPD upgrade), BBC large tiles were included, 
+    // so the BBCA volume (Annulus) was placed twice (small and large). 
+    // This made it a multi-placed volume, so it was included in the numbv array:
+    // numbv[0] = BBCM (West/East: 1 or 2)
+    // numbv[1] = BBCA (Annulus Small/Large: 1 or 2)
+    // numbv[2] = THXM (Triple Module: 1 to 6)
+    // numbv[3] = SHXT (Single Module: 1 to 3)
 
-    int _id = 1000 * numbv[0] + 100 * numbv[1] + 10 * numbv[2] + numbv[3];
+    // In the new geometry (2018 onwards), BBC large tiles were removed.
+    // BBCA is only placed once (small tiles only)
+    // The array elements shift left by one:
+    // numbv[0] = BBCM (West/East: 1 or 2)
+    // numbv[1] = THXM (Triple Module: 1 to 6)
+    // numbv[2] = SHXT (Single Module: 1 to 3)
+    // numbv[3] = 0 (Empty)
+      _id = 1000 * numbv[0] + 100 * 1 + 10 * numbv[1] + numbv[2];
+    }
+    else {
+      _id = 1000 * numbv[0] + 100 * numbv[1] + 10 * numbv[2] + numbv[3];
+    }
 
     return _id;
 

--- a/StRoot/StGeant4Maker/AgMLBsmdVolumeId.h
+++ b/StRoot/StGeant4Maker/AgMLBsmdVolumeId.h
@@ -105,7 +105,7 @@ public:
 
       if( !nav ) {
         LOG_FATAL << "No Pointer to Navigator" << endm;
-        return kStFatal;
+        return -1;
       }
 
       // SAVE CURRENT NAVIGATOR STATE

--- a/StRoot/StGeant4Maker/AgMLBsmdVolumeId.h
+++ b/StRoot/StGeant4Maker/AgMLBsmdVolumeId.h
@@ -100,17 +100,30 @@ public:
       eta_bin = (global_strip - 1) / 15 + 1;
     }
     else { //smdp
-      
+
       TGeoNavigator* nav = gGeoManager->GetCurrentNavigator();
+
+      if( !nav ) {
+        LOG_FATAL << "No Pointer to Navigator" << endm;
+        return kStFatal;
+      }
+
+      // SAVE CURRENT NAVIGATOR STATE
+      nav->PushPath();
+
       nav->CdUp();//go to csme
       nav->CdUp();//go to csda
+
       
       double masterPos[3] = {xg[0], xg[1], xg[2]}; //global hit position
       double localPos[3];
       //smdp is rotated 180 in phi 90 theta wrt tower
       //we have to un-rotate to get local coordinates
       nav->MasterToLocal(masterPos, localPos);
-      
+
+      // RESTORE NAVIGATOR STATE
+      nav->PopPath();
+
       double total_width {n_strip_phi * width_phi}; // ~22.4022
       double start_y     {  -total_width / 2.0   };
 
@@ -123,21 +136,6 @@ public:
                   + 1000      * phi_encoded
                   + 100       * forw_back
                   + strip;
-    // if(forw_back == 3)
-    // LOG_INFO << "BSMDP VolumeId: rileft=" << rileft
-    //          << ", phi_mod=" << phi_mod
-    //          << ", layer=" << layer
-    //          << ", xg[0]=" << xg[0]
-    //          << ", xg[1]=" << xg[1]
-    //          << ", xg[2]=" << xg[2]
-    //          << ", xl[0]=" << xl[0]
-    //          << ", xl[1]=" << xl[1]
-    //          << ", xl[2]=" << xl[2]
-    //          << ", strip=" << strip
-    //          << ", eta_bin=" << eta_bin
-    //          << ", volume_id=" << volume_id
-    //          << endm;
-
     return volume_id;
   };
 };


### PR DESCRIPTION
This pull request introduces updates to the volume ID calculation logic for the BBC and BSMD detectors to account for geometry changes and improve code safety. The main changes include adapting the BBC volume ID assignment to handle different geometry configurations and enhancing navigator state management in the BSMD code.

**BBC Volume ID calculation update:**

* Modified the `AgMLBbcVolumeId::id` method in `AgMLBbcVolumeId.h` to account for changes in detector geometry after the 2018 EPD upgrade. The calculation now checks for the presence of the "BBCMin" detector and adjusts the indexing of the `numbv` array accordingly, ensuring correct volume ID assignment for both old and new geometries.

**BSMD code safety and cleanup:**

* Added checks for a valid `TGeoNavigator` pointer and improved navigator state handling in `AgMLBsmdVolumeId` by saving and restoring the navigator path with `PushPath` and `PopPath`. This prevents navigation errors and potential crashes due to incorrect navigator state.
* Removed commented-out debug logging code in the `AgMLBsmdVolumeId` class, resulting in cleaner and more maintainable code.- fixed the bbc volume ids by checking for the version that has the inner tiles only

- fixed the bsmdp energy depostion in geant3 by saving the navigator state when calcuating the volume id for bsmdp and restoring it after.