### PR TITLE
FIx particle stack not showing Pi0s.

### DIFF
--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -417,12 +417,12 @@ struct SD2Table_MTD {
       g2t_hit.p[1]      = (hit->momentum_in[1] + hit->momentum_out[1]) * 0.5;
       g2t_hit.p[2]      = (hit->momentum_in[2] + hit->momentum_out[2]) * 0.5;
       g2t_hit.s_track   = hit->length;
-      
-      table -> AddAt( &g2t_hit );     
-
       int idtruth = hit->idtruth;
       g2t_track_st* trk = (g2t_track_st*)track->At(idtruth-1);
 
+      g2t_hit.next_tr_hit_p = trk->hit_mtd_p; // store next hit on the linked list
+      trk->hit_mtd_p = hit->id;               // this hit becomes the head of the linked list
+      table -> AddAt( &g2t_hit );
       trk->n_mtd_hit++;
       
     }
@@ -1439,7 +1439,7 @@ void StGeant4Maker::FinishEvent(){
 
   AddHits<St_g2t_emc_hit>( "FPDH", {"FLXF","FLGR","FPSC","FOSC"}, "g2t_fpd_hit", sd2table_emc ); // n.b. does not read out the flxf or flgr hit defined in the geom...
 
-  AddHits<St_g2t_ctf_hit>( "BTOH", {"BRSG"}, "g2t_tfr_hit", sd2table_ctf  );
+  AddHits<St_g2t_ctf_hit>( "BTOH", {"BRSG" , "GEMG"}, "g2t_tfr_hit", sd2table_ctf  );
   AddHits<St_g2t_vpd_hit>( "VPDH", {"VRAD"}, "g2t_vpd_hit", sd2table_vpd  );
   AddHits<St_g2t_mtd_hit>( "MUTH", {"MIGG","MTTT","MTTF"}, "g2t_mtd_hit", sd2table_mtd  );
 
@@ -1614,7 +1614,7 @@ void StGeant4Maker::Stepping(){
   TParticle* current = stack->GetCurrentTrack(); 
 
   // Get access to the current MC truth
-  StarMCParticle* truth = stack->GetParticleTable().back(); 
+  StarMCParticle* truth = stack->GetCurrentPersistentTrack(); 
 
   // Update the immediate track history
   UpdateHistory();

--- a/StRoot/StGeant4Maker/StMCParticleStack.cxx
+++ b/StRoot/StGeant4Maker/StMCParticleStack.cxx
@@ -203,7 +203,15 @@ void StMCParticleStack::PushTrack( int toDo, int parent, int pdg,
       {
 	vertex->addDaughter( mParticleTable.back() );  
       }
-
+    // Set the vertex parent to the mother track's persistent particle
+    if ( !isPrimary ) {
+      int mother = particle->GetFirstMother();
+      if ( mother >= 0 && mother < mArraySize && mPersistentTrack[mother] ) {
+        if ( !vertex->parent() ) {
+          vertex->setParent( mPersistentTrack[mother] );
+        }
+      }
+    }
     auto* navigator = gGeoManager->GetCurrentNavigator();
     auto* volume    = navigator->GetCurrentVolume();
     auto* medium    = volume->GetMedium();


### PR DESCRIPTION
StMCParticleStack.cxx
Decay vertices were not handled correctly in then particle stack, the decay vertex parent was never set to the track's persistent particle resulting in that decay particle being treated as parent of it's own.

StGeant4Maker.cxx
Photons from Pi0 decay fill the back of the particle table, resulting in Geant4Maker treating them as truth. This is easily fixed by getting the persistent track instead of manually getting the last element in the table. (if a pi0 decays into two photons, the second photon is going to be the result of GetParticleTable().back() instead of the pi0).
Added TOF info to the MTD by adding the next track hit to the g2t tables (not tested).
Added GEMG volume to the AddHits of the BTOF for older geometries.
