### PR TITLE
Update default BASELIB from SL24x to SL26x

### DIFF
--- a/StRoot/macros/geant4star/submit_simulation_jobs.py
+++ b/StRoot/macros/geant4star/submit_simulation_jobs.py
@@ -21,7 +21,7 @@ def main():
     # JOBDIR
     parser.add_argument( '-j', '--jobdir', dest='JOBDIR', default='/star/simu/simu/g4star/.simulations/job/', help="Job directory" )    
     # BASELIB
-    parser.add_argument( '-b', '--baselib', dest='BASELIB', default='SL24x', help="Specify the library" )
+    parser.add_argument( '-b', '--baselib', dest='BASELIB', default='SL26x', help="Specify the library" )
     # OVERLAY
     parser.add_argument(      '--overlay', dest='OVERLAY', default='config/v0.3.0-rhel7-root6.24.06', help="Spack overlay on the environment" )
     # GROUPDIR


### PR DESCRIPTION
This pull request makes a small update to the default simulation library used in the `submit_simulation_jobs.py` script. The default value for the `--baselib` argument is changed from `'SL24x'` to `'SL26x'`. 

- Updated the default value of the `BASELIB` argument in `submit_simulation_jobs.py` from `'SL24x'` to `'SL26x'` to use a newer library version.