### PR TITLE
fix: add a nullptr check for the CurrentPersistentTrack

### DIFF
--- a/StRoot/StGeant4Maker/StGeant4Maker.cxx
+++ b/StRoot/StGeant4Maker/StGeant4Maker.cxx
@@ -2077,7 +2077,7 @@ void StGeant4Maker::Stepping(){
 
   // Score interaction vertices on entrance / exit of a tracking region
   bool transitCheck = (0!=transit)&&IAttr("Scoring:Transit");
-  if ( 2==mCurrentTrackingRegion || transitCheck ) {
+  if ( truth && ( 2==mCurrentTrackingRegion || transitCheck ) ) {
 
     int nsec  = mc->NSecondaries();
 


### PR DESCRIPTION
The crash seen in geant3/4 embedding was because the CurrentPersistentTrack was null. This pr fixes that but more investigation need to be done in order to determine the reason we do not have a persistent track.