### PR TITLE
Merge g4 starsim embed macro

### DIFF
--- a/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.cxx
+++ b/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.cxx
@@ -27,6 +27,8 @@
 #include "TTree.h"
 #include "StGenericVertexMaker/StGenericVertexMaker.h"
 #include "StGenericVertexMaker/StGenericVertexFinder.h"
+#include "TDatabasePDG.h"
+
 
 #include "tables/St_vertexSeed_Table.h"
 #include "TString.h"
@@ -625,9 +627,26 @@ void StPrepEmbedMaker::Do(const Char_t *job)
 }
 
 //____________________________________________________________________________________________________
-void StPrepEmbedMaker::SetPartOpt(const Int_t pid, const Double_t mult)  
+void StPrepEmbedMaker::SetPartOpt(const Int_t pid, const Double_t mult,std::string type)  
 { 
-  mSettings->mult=mult; mSettings->pid=pid; 
+  mSettings->mult=mult;
+  int g3_pid = 0;
+
+
+  if (type == "pid" || type == "PID") {
+    g3_pid = pid;
+  } else if (type == "pdg" || type == "PDG") {
+    TDatabasePDG *pdgDB = TDatabasePDG::Instance();
+    g3_pid = pdgDB->ConvertPdgToGeant3(pid);
+    if (g3_pid < 1) {
+      LOG_ERROR << "StPrepEmbedMaker::SetPartOpt  PDG code " << pid << " not found in Geant3 database" << endm;
+    }
+  } else {
+    LOG_ERROR << "StPrepEmbedMaker::SetPartOpt  Unknown type '" << type << "', expected 'pid' or 'pdg'" << endm;
+  }
+  // TODO: better error handling if g3_pid is not valid
+  assert(g3_pid > 0);
+  mSettings->pid=g3_pid; 
   LOG_INFO << "StPrepEmbedMaker::SetPartOpt mult = " << mSettings->mult
 	   << " pid = " << mSettings->pid << endm;
 }

--- a/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.cxx
+++ b/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.cxx
@@ -27,7 +27,7 @@
 #include "TTree.h"
 #include "StGenericVertexMaker/StGenericVertexMaker.h"
 #include "StGenericVertexMaker/StGenericVertexFinder.h"
-#include "TDatabasePDG.h"
+#include "StarClassLibrary/StParticleTable.hh"
 
 
 #include "tables/St_vertexSeed_Table.h"
@@ -636,16 +636,17 @@ void StPrepEmbedMaker::SetPartOpt(const Int_t pid, const Double_t mult,std::stri
   if (type == "pid" || type == "PID") {
     g3_pid = pid;
   } else if (type == "pdg" || type == "PDG") {
-    TDatabasePDG *pdgDB = TDatabasePDG::Instance();
-    g3_pid = pdgDB->ConvertPdgToGeant3(pid);
+    StParticleTable *pdgtable = StParticleTable::instance();
+    assert(pdgtable);
+    g3_pid = pdgtable->geantId(pid);
     if (g3_pid < 1) {
       LOG_ERROR << "StPrepEmbedMaker::SetPartOpt  PDG code " << pid << " not found in Geant3 database" << endm;
+      // TODO: better error handling if g3_pid is not valid
+      assert(0);
     }
   } else {
     LOG_ERROR << "StPrepEmbedMaker::SetPartOpt  Unknown type '" << type << "', expected 'pid' or 'pdg'" << endm;
   }
-  // TODO: better error handling if g3_pid is not valid
-  assert(g3_pid > 0);
   mSettings->pid=g3_pid; 
   LOG_INFO << "StPrepEmbedMaker::SetPartOpt mult = " << mSettings->mult
 	   << " pid = " << mSettings->pid << endm;

--- a/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.cxx
+++ b/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.cxx
@@ -35,6 +35,8 @@
 #include "TSystem.h"
 
 #include <unistd.h>
+#include <cassert>
+#include <algorithm>
 
 ClassImp(StPrepEmbedMaker)
 struct embedSettings{
@@ -627,29 +629,35 @@ void StPrepEmbedMaker::Do(const Char_t *job)
 }
 
 //____________________________________________________________________________________________________
-void StPrepEmbedMaker::SetPartOpt(const Int_t pid, const Double_t mult,std::string type)  
+void StPrepEmbedMaker::SetPartOpt(const Int_t pid, const Double_t mult,const std::string& type)  
 { 
   mSettings->mult=mult;
   int g3_pid = 0;
 
+  auto string_lower = [](const std::string& str) -> std::string {
+    std::string lower_str = str;
+    std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(), ::tolower);
+    return lower_str;
+  };
 
-  if (type == "pid" || type == "PID") {
+  std::string type_lower = string_lower(type);
+
+  if (type_lower == "pid") {
     g3_pid = pid;
-  } else if (type == "pdg" || type == "PDG") {
+  } else if (type_lower == "pdg") {
     StParticleTable *pdgtable = StParticleTable::instance();
     assert(pdgtable);
     g3_pid = pdgtable->geantId(pid);
-    if (g3_pid < 1) {
-      LOG_ERROR << "StPrepEmbedMaker::SetPartOpt  PDG code " << pid << " not found in Geant3 database" << endm;
-      // TODO: better error handling if g3_pid is not valid
-      assert(0);
-    }
   } else {
     LOG_ERROR << "StPrepEmbedMaker::SetPartOpt  Unknown type '" << type << "', expected 'pid' or 'pdg'" << endm;
   }
+  assert(g3_pid > 0 && Form("StPrepEmbedMaker::SetPartOpt %d not found in Geant3 database", pid));
+
+  mSettings->mult=mult;
   mSettings->pid=g3_pid; 
   LOG_INFO << "StPrepEmbedMaker::SetPartOpt mult = " << mSettings->mult
 	   << " pid = " << mSettings->pid << endm;
+
 }
 
 //____________________________________________________________________________________________________

--- a/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.h
+++ b/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.h
@@ -18,6 +18,7 @@
 #ifndef StPrepEmbedMaker_hh     
 #define StPrepEmbedMaker_hh
 
+#include <string>
 #include "StMaker.h"
 #include "TGiant3.h"
 #include "TString.h"
@@ -45,8 +46,8 @@ class StPrepEmbedMaker : public StMaker {
     return cvs;
   }
   
-  void SetPartOpt(const Int_t pid, const Double_t mult, std::string type = "pid"); /// Set particle id, multiplicity and type of id ("PID" or "PDG")
-  /// "PID" is geantid() while "PDG" is pdg() from StParticleDataTable.  Default is "PID"
+  void SetPartOpt(const Int_t pid, const Double_t mult,const std::string& type = "pid"); /// Set particle id, multiplicity and type of id ("PID" or "PDG")
+  /// "PID" is geantid() while "PDG" is pdg() from StParticleDataTable.  Default is "pid"
 
   /// Set (ptlow, pthigh), (etalow, etahigh), (philow, phihigh), and type
   /// type can be

--- a/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.h
+++ b/StRoot/St_geant_Maker/Embed/StPrepEmbedMaker.h
@@ -45,7 +45,8 @@ class StPrepEmbedMaker : public StMaker {
     return cvs;
   }
   
-  void SetPartOpt(const Int_t pid, const Double_t mult); /// Set geantid(pid) and multiplicity
+  void SetPartOpt(const Int_t pid, const Double_t mult, std::string type = "pid"); /// Set particle id, multiplicity and type of id ("PID" or "PDG")
+  /// "PID" is geantid() while "PDG" is pdg() from StParticleDataTable.  Default is "PID"
 
   /// Set (ptlow, pthigh), (etalow, etahigh), (philow, phihigh), and type
   /// type can be

--- a/StRoot/macros/embedding/EmbeddingChainOptions.h
+++ b/StRoot/macros/embedding/EmbeddingChainOptions.h
@@ -30,10 +30,10 @@ struct EmbeddingChainOptions_t {
   std::string loadopts;   // concatination of all options, stripping out options which prevent loading libs needed in other chains
 };
 
-template< int simEngine > 
+// template< int simEngine > 
 struct EmbeddingChains {
 
-  EmbeddingChainOptions_t operator() ( const std::string& prodName, const bool readSim=false ) {
+  EmbeddingChainOptions_t operator() ( int simEngine, const std::string& prodName, const bool readSim=false ) {
 
     EmbeddingChainOptions_t result = { false, "", "", "", "" };
     

--- a/StRoot/macros/embedding/bfcMixer_TpxAll.C
+++ b/StRoot/macros/embedding/bfcMixer_TpxAll.C
@@ -4,7 +4,7 @@ class StMessMgr;
 
 #include <string>
 #include <TString.h>
-#include <TVirtualMC.h>
+// #include <TVirtualMC.h>
 
 #include "EmbeddingChainOptions.h"
 
@@ -14,10 +14,7 @@ const int debuglevel = 1;
 
 std::string   chain1opts_ = "in,magF,tpcDb,NoDefault,TpxRaw,-ittf,usexgeom,xgeometry stargen:stubs "; // agml??
 std::string   chain2opts_ = "gen_T,emc_T,geomT,sim_T,tpcrs     -ittf,-tpc_daq,nodefault stargen:embed kinematics:embed ry2021a g4star:mk ";
-//std::string   chain2opts_ = "gen_T,emc_T,geomT,sim_T,     -ittf,-tpc_daq,nodefault stargen:embed kinematics:embed ry2021a g4star:mk ";
-//std::string   chain2opts_ = "gen_T,emc_T,geomT,sim_T,TpcRS,-ittf,-tpc_daq,nodefault  ry2021a  ";
 std::string   chain3opts_ = "DbV20230818 P2021a StiCA BEmcChkStat EbyET0 ODistoSmear VFMCE TpxClu -VFMinuit -hitfilt TpcMixer MiniMcMk McAna useInTracker emcSim bemcMixer eefs eemcmixer nodefault";
-//std::string   chain3opts_ = "DbV20230818 P2021a StiCA BEmcChkStat EbyET0 ODistoSmear VFMCE TpxClu -VFMinuit -hitfilt TpcMixer " " MiniMcMk McAna useInTracker " " emcSim bemcMixer eefs eemcmixer nodefault";
 
 
 std::string   prepend = "";
@@ -81,6 +78,7 @@ std::vector<int> triggers = {870010};
 std::string prodName = "P23idAuAu17";
 std::string type = "FlatPT";
 std::string engine = "G4";
+int simcore = geant4star;
 std::string pidtype = "pid";
 
 struct DecayMode {
@@ -131,50 +129,78 @@ void process( const char* line ){
 };
 
 void SetTagFile( const char* tags ) {
-  process( "auto* stembed = dynamic_cast<StarEmbedMaker*>( StMaker::GetTopChain()->Maker(\"StarEmbed\") );");
-  process( Form("stembed->SetAttr(\"tags\",\"%s\");",tags) );
-  //  process( Form("stembed->SetInputFile(\"%s\");", tags ) );
-
+  if ( simcore == geant4star ) {
+    process( "auto* stembed = dynamic_cast<StarEmbedMaker*>( StMaker::GetTopChain()->Maker(\"StarEmbed\") );");
+    process( Form("stembed->SetAttr(\"tags\",\"%s\");",tags) );
+  } else if ( simcore == starsimR6 ) {
+    process( "#pragma cling add_include_path(\"StRoot\")               ");
+    process( "#include \"St_geant_Maker/Embed/StPrepEmbedMaker.h\"     ");
+    process( "auto* embmk = dynamic_cast<StPrepEmbedMaker*>( StMaker::GetTopChain()->Maker(\"PrepEmbed\") );" );
+    process( "assert(embmk);" );
+    process( Form( "embmk->SetTagFile(\"%s\");", tags ) );
+  }
 }
 void SetOpt( double ptmn, double ptmx, double etamn, double etamx, double phimn, double phimx, const char* type_ ) {
-  auto* kine = chain2->Maker("StarKine");
-  kine->SetAttr("ptlow", ptmn);
-  kine->SetAttr("pthigh", ptmx);
-  kine->SetAttr("etalow", etamn);
-  kine->SetAttr("etahigh", etamx);
-  kine->SetAttr("philow", phimn);
-  kine->SetAttr("phihigh", phimx);
-  kine->SetAttr("mode", "FlatPT" );
+  if ( simcore == geant4star ) {
+    auto* kine = chain2->Maker("StarKine");
+    kine->SetAttr("ptlow", ptmn);
+    kine->SetAttr("pthigh", ptmx);
+    kine->SetAttr("etalow", etamn);
+    kine->SetAttr("etahigh", etamx);
+    kine->SetAttr("philow", phimn);
+    kine->SetAttr("phihigh", phimx);
+    kine->SetAttr("mode", "FlatPT" );
+  } else if ( simcore == starsimR6 ) {
+    process( Form( "embmk->SetOpt( %f, %f, %f, %f, %f, %f, \"%s\" );   ", ptmn, ptmx, etamn, etamx, phimn, phimx, type_ ) );
+  }
 }
 void SetPartOpt( int pid, double mult, const char* pidtype="pid" ) {
-  // Map PID onto particle name
-  auto* kine = chain2->Maker("StarKine");
-  gMessMgr->Info() << "SetPartOpt " << pidtype << " " << pid << " " << mult << endm;
-  kine->SetAttr(pidtype,int(pid));
-  kine->SetAttr("ntrack", double(mult));
-  if ( mult < 1.0 ) {
-    auto* embed = chain2->Maker("StarEmbed");
-    LOG_INFO << "Setting eventmult=" << mult << endm;
-    embed->SetAttr("eventmult",double(mult));
+  if ( simcore == geant4star ) {
+    // Map PID onto particle name
+    auto* kine = chain2->Maker("StarKine");
+    gMessMgr->Info() << "SetPartOpt " << pidtype << " " << pid << " " << mult << endm;
+    kine->SetAttr(pidtype,int(pid));
+    kine->SetAttr("ntrack", double(mult));
+    if ( mult < 1.0 ) {
+      auto* embed = chain2->Maker("StarEmbed");
+      LOG_INFO << "Setting eventmult=" << mult << endm;
+      embed->SetAttr("eventmult",double(mult));
+    }
+  } else if ( simcore == starsimR6 ) {
+    process( Form( "embmk->SetPartOpt(%i,%f,\"%s\");", pid, mult, pidtype) );
+    process( "embmk->SetSkipMode(true);" );
+    process( "embmk->SetTemp(0.35);");
   }
 }
 void SetTriggers( std::vector<int> triggers ) {
-  auto* kine = chain2->Maker("StarEmbed");
-  std::string triglist = "";
-  for ( int t : triggers ) {
-    triglist += Form( "%i ", t );
+  if ( simcore == geant4star ) {
+    auto* kine = chain2->Maker("StarEmbed");
+    std::string triglist = "";
+    for ( int t : triggers ) {
+      triglist += Form( "%i ", t );
+    }
+    kine->SetAttr("triggers", triglist.c_str());
+  } else if ( simcore == starsimR6 ) {
+    for ( int t : triggers ) {
+      process( Form( "embmk->SetTrgOpt(%i);",t ) );
+    }
   }
-  kine->SetAttr("triggers", triglist.c_str());
 }
 void SetZVertexCut( double vzmn, double vzmx, double vr=-1.0 ) {
-  auto* embed = chain2->Maker("StarEmbed");  
-  embed->SetAttr("vzmin", vzmn);
-  embed->SetAttr("vzmax", vzmx);
-  embed->SetAttr("vrmax", vr );
+  if ( simcore == geant4star ) {
+    auto* embed = chain2->Maker("StarEmbed");  
+    embed->SetAttr("vzmin", vzmn);
+    embed->SetAttr("vzmax", vzmx);
+    embed->SetAttr("vrmax", vr );
+  } else if ( simcore == starsimR6 ) {
+    process( Form( "embmk->SetZVertexCut(%f, %f);", vzmn, vzmx ) );
+    if ( vr>0.0 )   
+      process( Form( "embmk->SetVrCut(%f);", vr ) );
+  }
 };
 
 
-void bfcMixer_TpxG4() 
+void bfcMixer_TpxAll() 
 {
 
   // Create the top level chain
@@ -230,8 +256,10 @@ void bfcMixer_TpxG4()
 
   if ( chain1 ) { chain1->cd();  chain1->Instantiate(); }
   if ( chain2 ) { chain2->cd();  chain2->Instantiate();
-    auto* prim=chain2->Maker("StarEmbed");
-    prim->SetAttr("output","genevents.root");
+    if ( simcore == geant4star ) {
+      auto* prim=chain2->Maker("StarEmbed");
+      prim->SetAttr("output","genevents.root");
+    }
   }
   if ( chain3 ) { chain3->cd();  chain3->Instantiate(); }
 
@@ -244,7 +272,7 @@ void bfcMixer_TpxG4()
   if ( chain2 ) {
     auto* tpcrs = chain2->Maker("TpcRS");
     if ( tpcrs ) {
-      tpcrs->SetAttr("inputds","geant4star");
+  if ( simcore == geant4star ) tpcrs->SetAttr("inputds","geant4star");
     }
   }
 
@@ -280,12 +308,6 @@ void bfcMixer_TpxG4()
     process( "kine_->SetAttr(\"rapidity\",1);" );
     process( "primary_ -> AddGenerator( kine_ );");
     
-    SetTagFile( tagfile.c_str() );
-    SetOpt( pt_low, pt_high, eta_low, eta_high, 0.0, TMath::TwoPi(), type.c_str() );
-    SetPartOpt( pid, mult, pidtype.c_str() );
-    SetZVertexCut( vzlow, vzhigh, vr );
-    SetTriggers( triggers );
-
     //
     // Configure G4 maker
     //
@@ -337,6 +359,13 @@ void bfcMixer_TpxG4()
 
   }
   
+  SetTagFile( tagfile.c_str() );
+  SetOpt( pt_low, pt_high, eta_low, eta_high, 0.0, TMath::TwoPi(), type.c_str() );
+  SetPartOpt( pid, mult, pidtype.c_str() );
+  SetZVertexCut( vzlow, vzhigh, vr );
+  SetTriggers( triggers );
+
+
   TAttr::SetDebug(0);
   
   //
@@ -345,7 +374,8 @@ void bfcMixer_TpxG4()
   top->SetAttr(".Privilege",0,"*"                ); 	//All  makers are NOT priviliged
   top->SetAttr(".Privilege",1,"StBFChain::*" ); 	//StBFChain is priviliged
   top->SetAttr(".Privilege",1,"StIOInterFace::*" ); 	//All IO makers are priviliged
-  //top->SetAttr(".Privilege",1,"St_geant_Maker::*"); 	//It is also IO maker
+  top->SetAttr(".Privilege",1,"St_geant_Maker::*"); 	//It is also IO maker
+  top->SetAttr(".Privilege",1,"StPrepEmbedMaker::*"); 	//It is also IO maker
   top->SetAttr(".Privilege",1,"StGeant4Maker::*"); 	//It is also IO maker
   top->SetAttr(".Privilege",1,"StarEmbedMaker::*"); 	//It is also IO maker
 
@@ -373,7 +403,7 @@ void bfcMixer_TpxG4()
 
 
 
-void bfcMixer_TpxG4( 
+void bfcMixer_TpxAll( 
 		    const int   nevents_ , 
 		    const char* daqfile_   = "/gpfs01/star/pwg/yelfeky/PicoThirdMaker/hpss_restore_with_tags/st_hf_adc_19101008_raw_3500011.daq", 
 		    const char* tagfile_   = "/gpfs01/star/pwg/yelfeky/PicoThirdMaker/hpss_restore_with_tags/st_hf_adc_19101008_raw_3500011.tags.root" , 
@@ -420,19 +450,15 @@ void bfcMixer_TpxG4(
 
   decayModes = decays_;
 
-
-  if ( engine != "G4" && engine != "G3" ) {
-    if ( engine == "starsimR6" ) {
-      std::cout << "starsimR6 is not yet supported in this macro" << std::endl;
-      std::cout << "Please use the bfcMixer_TpxAll.C macro for starsimR6" << std::endl;
-    } else{
-      std::cout << "Unknown simulation engine: " << engine << std::endl;
-    }
-    std::cout << "Valid options are: G4, G3" << std::endl;
+  if ( engine == "G4" || engine == "G3" ) simcore = geant4star;
+  else if ( engine == "starsimR6" ) simcore = starsimR6;
+  else {
+    std::cout << "Unknown simulation engine: " << engine << std::endl;
+    std::cout << "Valid options are: G4, G3, starsimR6" << std::endl;
     return;
   }
 
-  auto opts = getChainOptions( geant4star, prodName, simIn );
+  auto opts = getChainOptions(simcore, prodName, simIn );
 
   if ( opts.isValid ) {
     
@@ -440,7 +466,7 @@ void bfcMixer_TpxG4(
     chain1opts = opts.chain1 + " nooutput ";
     chain2opts = opts.chain2 + " noinput nooutput ";
     chain3opts = opts.chain3 + " -in noinput ";    
-    bfcMixer_TpxG4();
+    bfcMixer_TpxAll();
 
   }
 
@@ -455,7 +481,7 @@ void bfcMixer_TpxG4(
 
 };
 
-void bfcMixer_TpxG4( const char* dbg ) {
+void bfcMixer_TpxAll( const char* dbg ) {
 
   std::string dbg_ = dbg;
 
@@ -464,7 +490,7 @@ void bfcMixer_TpxG4( const char* dbg ) {
     const int   nevents_ = 50; 
     const char* mydaqfile_   = "/gpfs01/star/embed/daq/2021/auau17_phys_chop/st_physics_adc_22155034_raw_5500004.daq"   ;
     const char* mytagfile_   = "/gpfs01/star/embed/tags/2021/auau17_phys/st_physics_adc_22155034_raw_5500004.tags.root" ;
-    bfcMixer_TpxG4( 50, mydaqfile_, mytagfile_ );
+    bfcMixer_TpxAll( 50, mydaqfile_, mytagfile_ );
 
   };
 
@@ -485,7 +511,7 @@ void bfcMixer_TpxG4( const char* dbg ) {
     std::vector<int> mytriggers_  = {870010} ; 
     const char* myprodname  = "P23idAuAu17" ; 
     const char* mykintype   = "FlatPT"      ;
-    bfcMixer_TpxG4( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );
+    bfcMixer_TpxAll( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );
 
   };
 
@@ -507,7 +533,7 @@ void bfcMixer_TpxG4( const char* dbg ) {
     std::vector<int> mytriggers_  = {640001,640011,640021,640031,640041,640051} ; 
     const char* myprodname  = "P21icAuAu19" ; 
     const char* mykintype   = "FlatPT"      ;
-    bfcMixer_TpxG4( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );
+    bfcMixer_TpxAll( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );
   };
 
   /*
@@ -536,10 +562,10 @@ void bfcMixer_TpxG4( const char* dbg ) {
     //    DecayMode phiKK = decayMode( 333, {50.0, 321, -321, 0 }, {50.0, -321, 321, 0 } );
     //    decayModes.push_back( phiKK );			 
 
-    // bfcMixer_TpxG4( 100, "/star/data101/EMBED/daq/2019/079/20079022/st_physics_adc_20079022_raw_1000005.daq", "/star/data20/tags/production_19GeV_2019/ReversedFullField/P21ic/2019/079/20079022/st_physics_adc_20079022_raw_1000005.tags.root", 0., 6., -1., 1., -145., 145., 2.0, 333, 0.05, {640001,640011,640021,640031,640041,640051}, "P21icAuAu19" , "FlatPT", "pdg",        {    decayMode(  333, { 100.0,  321, -321,    0 } ),           decayMode(  321, { 100.0,  211,  211, -211 } ),         decayMode( -321, { 100.0, -211, -211,  211 } )       }
+    // bfcMixer_TpxAll( 100, "/star/data101/EMBED/daq/2019/079/20079022/st_physics_adc_20079022_raw_1000005.daq", "/star/data20/tags/production_19GeV_2019/ReversedFullField/P21ic/2019/079/20079022/st_physics_adc_20079022_raw_1000005.tags.root", 0., 6., -1., 1., -145., 145., 2.0, 333, 0.05, {640001,640011,640021,640031,640041,640051}, "P21icAuAu19" , "FlatPT", "pdg",        {    decayMode(  333, { 100.0,  321, -321,    0 } ),           decayMode(  321, { 100.0,  211,  211, -211 } ),         decayMode( -321, { 100.0, -211, -211,  211 } )       }
 
 
-    bfcMixer_TpxG4
+    bfcMixer_TpxAll
       ( 
        nevents_, 
        mydaqfile_, 
@@ -586,7 +612,7 @@ void bfcMixer_TpxG4( const char* dbg ) {
     const char* myprodname  = "P21idIsobar200"  ; 
     const char* mykintype   = "FlatPT"       ;
     bool mysimIn = false                     ;
-    bfcMixer_TpxG4( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );
+    bfcMixer_TpxAll( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );
      
   }
   /*
@@ -611,7 +637,7 @@ void bfcMixer_TpxG4( const char* dbg ) {
     const char* myprodname  = "P23ieAuAu200"  ; 
     const char* mykintype   = "FlatPT"       ;
     bool mysimIn = false                     ;
-    bfcMixer_TpxG4( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );     
+    bfcMixer_TpxAll( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );     
   }
 
   /*
@@ -635,7 +661,7 @@ void bfcMixer_TpxG4( const char* dbg ) {
     std::vector<int> mytriggers_  = {640001,640011,640021,640031,640041,640051} ; 
     const char* myprodname  = "P23idAuAu19" ; 
     const char* mykintype   = "FlatPT"      ;
-    bfcMixer_TpxG4( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );
+    bfcMixer_TpxAll( nevents_, mydaqfile_, mytagfile_, myptmn_, myptmx_, myetamn_, myetamx_, myvzmn_, myvzmx_, myvr_, mypid_, mymult_, mytriggers_, myprodname, mykintype );
   };
 
     
@@ -663,6 +689,6 @@ void bfcMixer_Tpx(
 		    const char* engine_ 
 		   ) {
 
-  bfcMixer_TpxG4( nevents_, daqfile_, tagfile_, ptmn_, ptmx_, etamn_, etamx_, vzmn_, vzmx_, vr_, pid_, mult_, triggers_, prodname, kintype, simIn, engine_ );
+  bfcMixer_TpxAll( nevents_, daqfile_, tagfile_, ptmn_, ptmx_, etamn_, etamx_, vzmn_, vzmx_, vr_, pid_, mult_, triggers_, prodname, kintype, simIn, engine_ );
 
 };

--- a/StRoot/macros/embedding/bfcMixer_TpxG4.C
+++ b/StRoot/macros/embedding/bfcMixer_TpxG4.C
@@ -32,7 +32,6 @@ const bool runchains[] = { false, true, true, true };
 
 // Load sufficient libraries to bootstrap the StBFChain framework
 #pragma cling load("libTree.so")
-#pragma cling load("libEG.so")
 #pragma cling load("StarRoot")
 #pragma cling load("St_base")
 #pragma cling load("StChain")
@@ -42,7 +41,6 @@ const bool runchains[] = { false, true, true, true };
 #pragma cling load("StStarLogger.so")
 #pragma cling load("StarClassLibrary.so")
 #pragma cling load("libmysqlclient.so")
-//#pragma cling load("libStarMiniCern.so")
 
 #if !(defined(__CINT__) || defined(__CLING__)) || defined(__MAKECINT__)
 

--- a/StRoot/macros/embedding/bfcMixer_TpxG4.C
+++ b/StRoot/macros/embedding/bfcMixer_TpxG4.C
@@ -147,7 +147,6 @@ void SetTagFile( const char* tags ) {
 }
 void SetOpt( double ptmn, double ptmx, double etamn, double etamx, double phimn, double phimx, const char* type_ ) {
   if ( simcore == geant4star ) {
-    std::cout << "HHHHHHHHHHHHHHHHHHHHH" << std::endl;
     auto* kine = chain2->Maker("StarKine");
     kine->SetAttr("ptlow", ptmn);
     kine->SetAttr("pthigh", ptmx);

--- a/StRoot/macros/embedding/bfcMixer_TpxG4.C
+++ b/StRoot/macros/embedding/bfcMixer_TpxG4.C
@@ -381,6 +381,7 @@ void bfcMixer_TpxG4()
   top->SetAttr(".Privilege",1,"StBFChain::*" ); 	//StBFChain is priviliged
   top->SetAttr(".Privilege",1,"StIOInterFace::*" ); 	//All IO makers are priviliged
   top->SetAttr(".Privilege",1,"St_geant_Maker::*"); 	//It is also IO maker
+  top->SetAttr(".Privilege",1,"StPrepEmbedMaker::*"); 	//It is also IO maker
   top->SetAttr(".Privilege",1,"StGeant4Maker::*"); 	//It is also IO maker
   top->SetAttr(".Privilege",1,"StarEmbedMaker::*"); 	//It is also IO maker
 

--- a/StRoot/macros/embedding/bfcMixer_TpxG4.C
+++ b/StRoot/macros/embedding/bfcMixer_TpxG4.C
@@ -4,12 +4,12 @@ class StMessMgr;
 
 #include <string>
 #include <TString.h>
-#include <TVirtualMC.h>
+// #include <TVirtualMC.h>
 
 #include "EmbeddingChainOptions.h"
 
 // Functor for the embedding chain options
-EmbeddingChains<geant4star> getChainOptions;
+EmbeddingChains getChainOptions;
 const int debuglevel = 1;
 
 std::string   chain1opts_ = "in,magF,tpcDb,NoDefault,TpxRaw,-ittf,usexgeom,xgeometry stargen:stubs "; // agml??
@@ -32,6 +32,7 @@ const bool runchains[] = { false, true, true, true };
 
 // Load sufficient libraries to bootstrap the StBFChain framework
 #pragma cling load("libTree.so")
+#pragma cling load("libEG.so")
 #pragma cling load("StarRoot")
 #pragma cling load("St_base")
 #pragma cling load("StChain")
@@ -82,6 +83,7 @@ std::vector<int> triggers = {870010};
 std::string prodName = "P23idAuAu17";
 std::string type = "FlatPT";
 std::string engine = "G4";
+int simcore = geant4star;
 std::string pidtype = "pid";
 
 struct DecayMode {
@@ -132,58 +134,75 @@ void process( const char* line ){
 };
 
 void SetTagFile( const char* tags ) {
-  //  process( "#pragma cling add_include_path(\"StRoot\")               ");
-  //  process( "#include \"St_geant_Maker/Embed/StPrepEmbedMaker.h\"     ");
-  //  process( "auto* embmk = dynamic_cast<StPrepEmbedMaker*>( StMaker::GetTopChain()->Maker(\"PrepEmbed\") );");
-  //  process( "assert(embmk);                                           ");
-  //  process( Form( "embmk->SetTagFile(\"%s\");                         ", tags ) );
-  process( "auto* stembed = dynamic_cast<StarEmbedMaker*>( StMaker::GetTopChain()->Maker(\"StarEmbed\") );");
-  process( Form("stembed->SetAttr(\"tags\",\"%s\");",tags) );
-  //  process( Form("stembed->SetInputFile(\"%s\");", tags ) );
-
+  if ( simcore == geant4star ) {
+    process( "auto* stembed = dynamic_cast<StarEmbedMaker*>( StMaker::GetTopChain()->Maker(\"StarEmbed\") );");
+    process( Form("stembed->SetAttr(\"tags\",\"%s\");",tags) );
+  } else if ( simcore == starsimR6 ) {
+    process( "#pragma cling add_include_path(\"StRoot\")               ");
+    process( "#include \"St_geant_Maker/Embed/StPrepEmbedMaker.h\"     ");
+    process( "auto* embmk = dynamic_cast<StPrepEmbedMaker*>( StMaker::GetTopChain()->Maker(\"PrepEmbed\") );" );
+    process( "assert(embmk);" );
+    process( Form( "embmk->SetTagFile(\"%s\");", tags ) );
+  }
 }
 void SetOpt( double ptmn, double ptmx, double etamn, double etamx, double phimn, double phimx, const char* type_ ) {
-  //  process( Form( "embmk->SetOpt( %f, %f, %f, %f, %f, %f, \"%s\" );   ", ptmn, ptmx, etamn, etamx, phimn, phimx, type_ ) );
-  auto* kine = chain2->Maker("StarKine");
-  kine->SetAttr("ptlow", ptmn);
-  kine->SetAttr("pthigh", ptmx);
-  kine->SetAttr("etalow", etamn);
-  kine->SetAttr("etahigh", etamx);
-  kine->SetAttr("philow", phimn);
-  kine->SetAttr("phihigh", phimx);
-  kine->SetAttr("mode", "FlatPT" );
+  if ( simcore == geant4star ) {
+    std::cout << "HHHHHHHHHHHHHHHHHHHHH" << std::endl;
+    auto* kine = chain2->Maker("StarKine");
+    kine->SetAttr("ptlow", ptmn);
+    kine->SetAttr("pthigh", ptmx);
+    kine->SetAttr("etalow", etamn);
+    kine->SetAttr("etahigh", etamx);
+    kine->SetAttr("philow", phimn);
+    kine->SetAttr("phihigh", phimx);
+    kine->SetAttr("mode", "FlatPT" );
+  } else if ( simcore == starsimR6 ) {
+    process( Form( "embmk->SetOpt( %f, %f, %f, %f, %f, %f, \"%s\" );   ", ptmn, ptmx, etamn, etamx, phimn, phimx, type_ ) );
+  }
 }
 void SetPartOpt( int pid, double mult, const char* pidtype="pid" ) {
-  // Map PID onto particle name
-  auto* kine = chain2->Maker("StarKine");
-  gMessMgr->Info() << "SetPartOpt " << pidtype << " " << pid << " " << mult << endm;
-  kine->SetAttr(pidtype,int(pid));
-  kine->SetAttr("ntrack", double(mult));
-  if ( mult < 1.0 ) {
-    auto* embed = chain2->Maker("StarEmbed");
-    LOG_INFO << "Setting eventmult=" << mult << endm;
-    embed->SetAttr("eventmult",double(mult));
+  if ( simcore == geant4star ) {
+    // Map PID onto particle name
+    auto* kine = chain2->Maker("StarKine");
+    gMessMgr->Info() << "SetPartOpt " << pidtype << " " << pid << " " << mult << endm;
+    kine->SetAttr(pidtype,int(pid));
+    kine->SetAttr("ntrack", double(mult));
+    if ( mult < 1.0 ) {
+      auto* embed = chain2->Maker("StarEmbed");
+      LOG_INFO << "Setting eventmult=" << mult << endm;
+      embed->SetAttr("eventmult",double(mult));
+    }
+  } else if ( simcore == starsimR6 ) {
+    process( Form( "embmk->SetPartOpt(%i,%f,\"%s\");", pid, mult, pidtype) );
+    process( "embmk->SetSkipMode(true);" );
+    process( "embmk->SetTemp(0.35);");
   }
 }
 void SetTriggers( std::vector<int> triggers ) {
-  auto* kine = chain2->Maker("StarEmbed");
-  std::string triglist = "";
-  for ( int t : triggers ) {
-    //    process( Form( "embmk->SetTriOpt(%i);",t ) );
-    triglist += Form( "%i ", t );
+  if ( simcore == geant4star ) {
+    auto* kine = chain2->Maker("StarEmbed");
+    std::string triglist = "";
+    for ( int t : triggers ) {
+      triglist += Form( "%i ", t );
+    }
+    kine->SetAttr("triggers", triglist.c_str());
+  } else if ( simcore == starsimR6 ) {
+    for ( int t : triggers ) {
+      process( Form( "embmk->SetTrgOpt(%i);",t ) );
+    }
   }
-  kine->SetAttr("triggers", triglist.c_str());
 }
 void SetZVertexCut( double vzmn, double vzmx, double vr=-1.0 ) {
-  //  process( Form( "embmk->SetZVertexCut(%f, %f);", vzmn, vzmx ) );
-  //  if ( vr>0.0 )   
-  //    process( Form( "embmk->SetVrCut(%f);", vr ) );
-
-  auto* embed = chain2->Maker("StarEmbed");  
-  embed->SetAttr("vzmin", vzmn);
-  embed->SetAttr("vzmax", vzmx);
-  embed->SetAttr("vrmax", vr );
-
+  if ( simcore == geant4star ) {
+    auto* embed = chain2->Maker("StarEmbed");  
+    embed->SetAttr("vzmin", vzmn);
+    embed->SetAttr("vzmax", vzmx);
+    embed->SetAttr("vrmax", vr );
+  } else if ( simcore == starsimR6 ) {
+    process( Form( "embmk->SetZVertexCut(%f, %f);", vzmn, vzmx ) );
+    if ( vr>0.0 )   
+      process( Form( "embmk->SetVrCut(%f);", vr ) );
+  }
 };
 
 
@@ -234,7 +253,7 @@ void bfcMixer_TpxG4()
     chain3 -> SetFlags( chain3opts.c_str() );
     chain3 -> SetName("Three");
     TString outfile = gSystem->BaseName(daqfile.c_str());    
-    outfile.ReplaceAll(".daq","_G4.root");
+    outfile.ReplaceAll(".daq",Form("_%s.root", engine.c_str()));
     chain3->Set_IO_Files(nullptr, outfile);
   };
 
@@ -243,8 +262,10 @@ void bfcMixer_TpxG4()
 
   if ( chain1 ) { chain1->cd();  chain1->Instantiate(); }
   if ( chain2 ) { chain2->cd();  chain2->Instantiate();
-    auto* prim=chain2->Maker("StarEmbed");
-    prim->SetAttr("output","genevents.root");
+    if ( simcore == geant4star ) {
+      auto* prim=chain2->Maker("StarEmbed");
+      prim->SetAttr("output","genevents.root");
+    }
   }
   if ( chain3 ) { chain3->cd();  chain3->Instantiate(); }
 
@@ -257,7 +278,7 @@ void bfcMixer_TpxG4()
   if ( chain2 ) {
     auto* tpcrs = chain2->Maker("TpcRS");
     if ( tpcrs ) {
-      tpcrs->SetAttr("inputds","geant4star");
+  if ( simcore == geant4star ) tpcrs->SetAttr("inputds","geant4star");
     }
   }
 
@@ -270,7 +291,7 @@ void bfcMixer_TpxG4()
 
   if ( chain3 ) { 
     chain3->cd();
-    auto* tpxmixer = chain3->Maker("TpcMixer"); assert(tpcmixer);
+    auto* tpxmixer = chain3->Maker("TpcMixer"); assert(tpxmixer);
     tpxmixer -> SetInput( "Input1", "TpxRaw/.data/Event" );
     tpxmixer -> SetInput( "Input2", "TpcRS/Event" );
 
@@ -293,12 +314,6 @@ void bfcMixer_TpxG4()
     process( "kine_->SetAttr(\"rapidity\",1);" );
     process( "primary_ -> AddGenerator( kine_ );");
     
-    SetTagFile( tagfile.c_str() );
-    SetOpt( pt_low, pt_high, eta_low, eta_high, 0.0, TMath::TwoPi(), type.c_str() );
-    SetPartOpt( pid, mult, pidtype.c_str() );
-    SetZVertexCut( vzlow, vzhigh, vr );
-    SetTriggers( triggers );
-
     //
     // Configure G4 maker
     //
@@ -350,6 +365,13 @@ void bfcMixer_TpxG4()
 
   }
   
+  SetTagFile( tagfile.c_str() );
+  SetOpt( pt_low, pt_high, eta_low, eta_high, 0.0, TMath::TwoPi(), type.c_str() );
+  SetPartOpt( pid, mult, pidtype.c_str() );
+  SetZVertexCut( vzlow, vzhigh, vr );
+  SetTriggers( triggers );
+
+
   TAttr::SetDebug(0);
   
   //
@@ -358,7 +380,7 @@ void bfcMixer_TpxG4()
   top->SetAttr(".Privilege",0,"*"                ); 	//All  makers are NOT priviliged
   top->SetAttr(".Privilege",1,"StBFChain::*" ); 	//StBFChain is priviliged
   top->SetAttr(".Privilege",1,"StIOInterFace::*" ); 	//All IO makers are priviliged
-  //top->SetAttr(".Privilege",1,"St_geant_Maker::*"); 	//It is also IO maker
+  top->SetAttr(".Privilege",1,"St_geant_Maker::*"); 	//It is also IO maker
   top->SetAttr(".Privilege",1,"StGeant4Maker::*"); 	//It is also IO maker
   top->SetAttr(".Privilege",1,"StarEmbedMaker::*"); 	//It is also IO maker
 
@@ -433,7 +455,15 @@ void bfcMixer_TpxG4(
 
   decayModes = decays_;
 
-  auto opts = getChainOptions( prodName, simIn );
+  if ( engine == "G4" || engine == "G3" ) simcore = geant4star;
+  else if ( engine == "starsimR6" ) simcore = starsimR6;
+  else {
+    std::cout << "Unknown simulation engine: " << engine << std::endl;
+    std::cout << "Valid options are: G4, G3, starsimR6" << std::endl;
+    return;
+  }
+
+  auto opts = getChainOptions(simcore, prodName, simIn );
 
   if ( opts.isValid ) {
     

--- a/StRoot/macros/embedding/bfcMixer_TpxR6.C
+++ b/StRoot/macros/embedding/bfcMixer_TpxR6.C
@@ -25,7 +25,6 @@ const bool runchains[] = { false, true, true, true };
 
 // Load sufficient libraries to bootstrap the StBFChain framework
 #pragma cling load("libTree.so")
-#pragma cling load("libEG.so")
 #pragma cling load("StarRoot")
 #pragma cling load("St_base")
 #pragma cling load("StChain")

--- a/StRoot/macros/embedding/bfcMixer_TpxR6.C
+++ b/StRoot/macros/embedding/bfcMixer_TpxR6.C
@@ -155,7 +155,7 @@ void bfcMixer_TpxR6()
     chain3 -> SetFlags( chain3opts.c_str() );
     chain3 -> SetName("Three");
     TString outfile = gSystem->BaseName(daqfile.c_str());    
-    outfile.ReplaceAll(".daq","_R6.root");
+    outfile.ReplaceAll(".daq","_starsimR6.root");
     chain3->Set_IO_Files(nullptr, outfile);    
   }
 

--- a/StRoot/macros/embedding/bfcMixer_TpxR6.C
+++ b/StRoot/macros/embedding/bfcMixer_TpxR6.C
@@ -25,6 +25,7 @@ const bool runchains[] = { false, true, true, true };
 
 // Load sufficient libraries to bootstrap the StBFChain framework
 #pragma cling load("libTree.so")
+#pragma cling load("libEG.so")
 #pragma cling load("StarRoot")
 #pragma cling load("St_base")
 #pragma cling load("StChain")

--- a/StRoot/macros/embedding/bfcMixer_TpxR6.C
+++ b/StRoot/macros/embedding/bfcMixer_TpxR6.C
@@ -6,7 +6,7 @@ class StMessMgr;
 #include "EmbeddingChainOptions.h"
 
 // Functor for the embedding chain options
-EmbeddingChains<starsimR6> getChainOptions;
+EmbeddingChains getChainOptions;
 
 const int debuglevel = 1;
 
@@ -175,7 +175,7 @@ void bfcMixer_TpxR6()
 
   if ( chain3 ) {
     chain3->cd();
-    auto* tpxmixer = chain3->Maker("TpcMixer"); assert(tpcmixer);
+    auto* tpxmixer = chain3->Maker("TpcMixer"); assert(tpxmixer);
     if ( tpxmixer ) {
       tpxmixer -> SetInput( "Input1", "TpxRaw/.data/Event" );
       tpxmixer -> SetInput( "Input2", "TpcRS/Event" );
@@ -261,7 +261,7 @@ void bfcMixer_TpxR6(
   daqfile=daqfile_;
   tagfile=tagfile_;
 
-  auto opts = getChainOptions( prodName, simIn );
+  auto opts = getChainOptions(starsimR6, prodName, simIn );
 
   if ( opts.isValid ) {
     

--- a/StRoot/macros/embedding/submit_geant4embedding.xml
+++ b/StRoot/macros/embedding/submit_geant4embedding.xml
@@ -129,7 +129,16 @@ void runBfc() {
 };
 EOF
 cat runBfc.C
-root -q -b runBfc.C
+
+set engine = "&ENGINE;"
+
+if ( "$engine" == "starsimR6" ) then
+  echo "Running $engine engine using root4star"
+  root4star -b -q runBfc.C
+else 
+  echo "Running $engine engine using root"
+  root -q -b runBfc.C
+endif
   
 ls -la .
 

--- a/StRoot/macros/embedding/submit_geant4embedding.xml
+++ b/StRoot/macros/embedding/submit_geant4embedding.xml
@@ -146,7 +146,7 @@ endif
 ls -la .
 
 <!-- Make output and list directory (if they don't exist) -->
-if ( ! -f &OUTDIR; ) then
+if ( ! -d &OUTDIR; ) then
   mkdir -pv &OUTDIR;
 endif
 ls -l &OUTDIR;

--- a/StRoot/macros/embedding/submit_geant4embedding.xml
+++ b/StRoot/macros/embedding/submit_geant4embedding.xml
@@ -104,6 +104,9 @@ cp StRoot/macros/embedding/EmbeddingChainOptions.h .
 echo Where is root
 which root
 
+echo Where is root4star
+which root4star
+
 echo List macros directory
 ls -l StRoot/macros/embedding/
 

--- a/StRoot/macros/embedding/submit_geant4embedding.xml
+++ b/StRoot/macros/embedding/submit_geant4embedding.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE note [                                                                                                                                                                        
-<!ENTITY PRODNAME "P21icAuAu19" >                                                                                                           
-<!ENTITY OFFSET "0">                                                                                                                                                                    
+<!DOCTYPE note [
+<!ENTITY PRODNAME "P21icAuAu19" >
+<!ENTITY OFFSET "0">
 <!ENTITY NEVENTS "1000">
 <!ENTITY NFILES "ALL">
 <!ENTITY DAQLIST "/star/simu/simu/jwebb/2026/production-filelists/P21ic:production_19GeV_2019:st_physics_adc.daqlist">
@@ -13,7 +13,7 @@
 <!ENTITY VZMN "-145.0">
 <!ENTITY VZMX "145.0">
 <!ENTITY VRMX "2.0">
-<!ENTITY PIDTYPE "PDG"> 
+<!ENTITY PIDTYPE "PDG">
 <!ENTITY PID "333">
 <!ENTITY MULT "0.05">
 <!ENTITY KINTYPE "FlatPT">
@@ -21,14 +21,14 @@
 <!ENTITY TRIGGERS "640001,640011,640021,640031,640041,640051">
 <!ENTITY DECAYS   "decayMode(333,{100.0,321,-321, 0}), decayMode(321,{100.0,211,211,-211}), decayMode(-321,{100.0,-211,-211,211}) ">
 <!ENTITY ENGINE   "G4">
-<!ENTITY OUTDIR "/star/simu/simu/g4star/.embedding/out/">                                                                                                                             
-<!ENTITY LOGDIR "/star/simu/simu/g4star/.embedding/log/">                                                                                                                             
+<!ENTITY OUTDIR "/star/simu/simu/g4star/.embedding/out/">
+<!ENTITY LOGDIR "/star/simu/simu/g4star/.embedding/log/">
 <!ENTITY JOBDIR "/star/simu/simu/g4star/.embedding/job/">
 <!ENTITY MACROSDIR "${STAR}/StRoot/macros">
 <!ENTITY WORKINGDIR "/star/simu/simu/jwebb/2026/Geant4STAR/geant4star-sl26-prune">
-<!ENTITY verbose "False">                                                                                                                                                               
+<!ENTITY verbose "False">
 <!ENTITY nosubmit "false">
-]>  
+]>
 
 <job maxFilesPerProcess="1" fileListSyntax="paths" simulateSubmission="&nosubmit;">
 
@@ -93,7 +93,7 @@ mkdir -v $SCRATCH/tags
 set tagfile=`grep ${FILEBASENAME} &TAGLIST;`
 cp -v   ${tagfile} $SCRATCH/tags/
 ls -lah $SCRATCH/
-ls -lah $SCRATCH/tags/ 
+ls -lah $SCRATCH/tags/
 
 touch $SCRATCH/${FILEBASENAME}_${JOBID}.log
 
@@ -115,18 +115,18 @@ echo STAR version is $STAR
 echo Create the run macro
 touch runBfc.C
 cat &lt;&lt;EOF &gt;&gt; runBfc.C
-#include "StRoot/macros/embedding/bfcMixer_TpxG4.C"
+#include "StRoot/macros/embedding/bfcMixer_TpxAll.C"
 void runBfc() {
-     bfcMixer_TpxG4(
+     bfcMixer_TpxAll(
      &NEVENTS;,
      "$INPUTFILE0",
      "$SCRATCH/tags/${FILEBASENAME}.tags.root",
-     &PTMN;, &PTMX;, &ETAMN;, &ETAMX;, &VZMN;, &VZMX;, &VRMX;, &PID;, &MULT;, 
+     &PTMN;, &PTMX;, &ETAMN;, &ETAMX;, &VZMN;, &VZMX;, &VRMX;, &PID;, &MULT;,
      {&TRIGGERS;},   // comma separated list of triggers is inserted into a vector of triggers
-     "&PRODNAME;", 
+     "&PRODNAME;",
      "&KINTYPE;",
      &SIMIN;,
-     "&PIDTYPE;", 
+     "&PIDTYPE;",
      {&DECAYS;},    // comma separated list of decay modes is inserted into a vector of decay modes
      "&ENGINE;");
 };
@@ -138,21 +138,21 @@ set engine = "&ENGINE;"
 if ( "$engine" == "starsimR6" ) then
   echo "Running $engine engine using root4star"
   root4star -b -q runBfc.C
-else 
+else
   echo "Running $engine engine using root"
   root -q -b runBfc.C
 endif
-  
+
 ls -la .
 
 <!-- Make output and list directory (if they don't exist) -->
-if ( ! -f &OUTDIR; ) then 
+if ( ! -f &OUTDIR; ) then
   mkdir -pv &OUTDIR;
 endif
 ls -l &OUTDIR;
 
 
-if ( ! -f &LOGDIR; ) then 
+if ( ! -f &LOGDIR; ) then
   mkdir -pv &LOGDIR;
 endif
 


### PR DESCRIPTION
Merge geant4star and starsimR6 embedding macros. The following is changed:
1. bfcMixer_TpxG4.C now supports stsrsimR6 engine, which involves changes to EmbeddingChainOptions.h to make it more modular.
2. StPreEmbedMaker now supports pdg codes as particle input.